### PR TITLE
iesy-base-image: add weston to IMAGE_FEATURES when using iesy-wayland

### DIFF
--- a/recipes-iesy/images/iesy-base-image.bb
+++ b/recipes-iesy/images/iesy-base-image.bb
@@ -14,6 +14,7 @@ inherit core-image ${@'features_check-poky' if "meta-rockchip" in d.getVar('BBLA
 
 IMAGE_FEATURES += " \
     ssh-server-openssh \
+    ${@bb.utils.contains('DISTRO', 'iesy-wayland', 'weston', '', d)} \
     "
 
 # This would also be set by default in local.conf. debug-tweaks is useful for development purposes.


### PR DESCRIPTION
this triggers systemd to use the default target graphical, which will start weston automatically