### PR TITLE
i.MX8MM EVA MI: add SPI B

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.15.87/0005-spi-add-m95m04-to-spidev.patch
+++ b/recipes-kernel/linux/linux-fslc-imx_5.15.87/0005-spi-add-m95m04-to-spidev.patch
@@ -1,0 +1,33 @@
+From 4f8a42ca0a73d200c849dedee91c60c40b01c7d5 Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Fri, 20 Oct 2023 12:00:47 +0200
+Subject: [PATCH 5/6] spi: add m95m04 to spidev
+
+add eeprom to generic spidev driver
+---
+ drivers/spi/spidev.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/spi/spidev.c b/drivers/spi/spidev.c
+index d233e2424ad1..732de307e93f 100644
+--- a/drivers/spi/spidev.c
++++ b/drivers/spi/spidev.c
+@@ -693,6 +693,7 @@ static const struct spi_device_id spidev_spi_ids[] = {
+ 	{ .name = "m53cpld" },
+ 	{ .name = "spi-petra" },
+ 	{ .name = "spi-authenta" },
++	{ .name = "m95m04" },
+ 	{},
+ };
+ MODULE_DEVICE_TABLE(spi, spidev_spi_ids);
+@@ -707,6 +708,7 @@ static const struct of_device_id spidev_dt_ids[] = {
+ 	{ .compatible = "menlo,m53cpld" },
+ 	{ .compatible = "cisco,spi-petra" },
+ 	{ .compatible = "micron,spi-authenta" },
++	{ .compatible = "st,m95m04" },
+ 	{},
+ };
+ MODULE_DEVICE_TABLE(of, spidev_dt_ids);
+-- 
+2.30.2
+

--- a/recipes-kernel/linux/linux-fslc-imx_5.15.87/0006-arm64-dts-iesy-iesy-imx8mm-eva-mi-add-SPI-B.patch
+++ b/recipes-kernel/linux/linux-fslc-imx_5.15.87/0006-arm64-dts-iesy-iesy-imx8mm-eva-mi-add-SPI-B.patch
@@ -1,0 +1,34 @@
+From 4eb2b6ecbf66f6dc238dd99e620065e2ff21b331 Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Fri, 20 Oct 2023 12:03:48 +0200
+Subject: [PATCH 6/6] arm64: dts: iesy: iesy-imx8mm-eva-mi: add SPI B
+
+---
+ arch/arm64/boot/dts/iesy/iesy-imx8mm-osm-sf.dtsi | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/iesy/iesy-imx8mm-osm-sf.dtsi b/arch/arm64/boot/dts/iesy/iesy-imx8mm-osm-sf.dtsi
+index 4ef12b9f0cdf..ff03b0a0838d 100644
+--- a/arch/arm64/boot/dts/iesy/iesy-imx8mm-osm-sf.dtsi
++++ b/arch/arm64/boot/dts/iesy/iesy-imx8mm-osm-sf.dtsi
+@@ -177,6 +177,17 @@ &wdog1 {
+ 	status = "okay";
+ };
+ 
++/* SPI B */
++&ecspi1 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	fsl,spi-num-chipselects = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_ecspi1 &pinctrl_ecspi1_cs>;
++	cs-gpios = <&gpio5 9 GPIO_ACTIVE_LOW>;
++	status = "disabled";
++};
++
+ &i2c1 {
+ 	clock-frequency = <400000>;
+ 	pinctrl-names = "default", "gpio";
+-- 
+2.30.2
+

--- a/recipes-kernel/linux/linux-fslc-imx_5.15.bbappend
+++ b/recipes-kernel/linux/linux-fslc-imx_5.15.bbappend
@@ -6,6 +6,8 @@ SRC_URI += " \
     file://0002-arm64-dts-iesy-iesy-imx8mm-eva-mi-Rev2-hardware.patch \
     file://0003-arm64-dts-iesy-iesy-imx8mm-eva-mi-add-LT8912.patch \
     file://0004-arm64-dts-iesy-iesy-imx8mm-eva-mi-config-usdhc1-for-.patch \
+    file://0005-spi-add-m95m04-to-spidev.patch \
+    file://0006-arm64-dts-iesy-iesy-imx8mm-eva-mi-add-SPI-B.patch \
 "
 
 


### PR DESCRIPTION
After switching the kernel the dt node for SPI B was missing, fixed it. Also added m95m04 to spidev driver for testing SPI B