### PR TITLE
i.MX8MM EVA MI: fix PCIe

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.15.87/0007-arm64-dts-iesy-iesy-imx8mm-eva-mi-fix-PCIe.patch
+++ b/recipes-kernel/linux/linux-fslc-imx_5.15.87/0007-arm64-dts-iesy-iesy-imx8mm-eva-mi-fix-PCIe.patch
@@ -1,0 +1,62 @@
+From 1f0239cd124558e49f12af92368d669f63de4857 Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Tue, 24 Oct 2023 15:07:29 +0200
+Subject: [PATCH 7/7] arm64: dts: iesy: iesy-imx8mm-eva-mi: fix PCIe
+
+---
+ .../boot/dts/iesy/iesy-imx8mm-eva-mi.dts      | 27 +++++--------------
+ 1 file changed, 6 insertions(+), 21 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/iesy/iesy-imx8mm-eva-mi.dts b/arch/arm64/boot/dts/iesy/iesy-imx8mm-eva-mi.dts
+index 32f93e693ee8b..e147de61c2653 100644
+--- a/arch/arm64/boot/dts/iesy/iesy-imx8mm-eva-mi.dts
++++ b/arch/arm64/boot/dts/iesy/iesy-imx8mm-eva-mi.dts
+@@ -116,15 +116,6 @@ pcie0_refclk: pcie0-refclk {
+ 		#clock-cells = <0>;
+ 		clock-frequency = <100000000>;
+ 	};
+-
+-	reg_pcie0: regulator-pcie {
+-		compatible = "regulator-fixed";
+-		pinctrl-names = "default";
+-		regulator-name = "MPCIE_3V3";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		enable-active-high;
+-	};	
+ };
+ 
+ &fec1 {
+@@ -149,23 +140,17 @@ ethphy0: ethernet-phy@0 {
+ };
+ 
+ &pcie0 {
+-	reset-gpio = <&gpio4 21 GPIO_ACTIVE_LOW>;
+ 	clocks = <&clk IMX8MM_CLK_PCIE1_ROOT>, <&clk IMX8MM_CLK_PCIE1_AUX>,
+-			 <&pcie0_refclk>;
+-	clock-names = "pcie", "pcie_aux", "pcie_bus";
++		<&clk IMX8MM_CLK_PCIE1_PHY>,
++		<&pcie0_refclk>;
++	clock-names = "pcie", "pcie_aux", "pcie_phy", "pcie_bus";
+ 	assigned-clocks = <&clk IMX8MM_CLK_PCIE1_AUX>,
++			  <&clk IMX8MM_CLK_PCIE1_PHY>,
+ 			  <&clk IMX8MM_CLK_PCIE1_CTRL>;
+-	assigned-clock-rates = <10000000>, <250000000>;
++	assigned-clock-rates = <10000000>, <100000000>, <250000000>;
+ 	assigned-clock-parents = <&clk IMX8MM_SYS_PLL2_50M>,
++				 <&clk IMX8MM_SYS_PLL2_100M>,
+ 				 <&clk IMX8MM_SYS_PLL2_250M>;
+-	vpcie-supply = <&reg_pcie0>;
+-	status = "okay";
+-	ext_osc = <0>;
+-};
+-
+-&pcie_phy {
+-	fsl,refclk-pad-mode = <2>;
+-	fsl,clkreq-unsupported;
+ 	ext_osc = <0>;
+ 	status = "okay";
+ };
+-- 
+2.30.2
+

--- a/recipes-kernel/linux/linux-fslc-imx_5.15.bbappend
+++ b/recipes-kernel/linux/linux-fslc-imx_5.15.bbappend
@@ -8,6 +8,7 @@ SRC_URI += " \
     file://0004-arm64-dts-iesy-iesy-imx8mm-eva-mi-config-usdhc1-for-.patch \
     file://0005-spi-add-m95m04-to-spidev.patch \
     file://0006-arm64-dts-iesy-iesy-imx8mm-eva-mi-add-SPI-B.patch \
+    file://0007-arm64-dts-iesy-iesy-imx8mm-eva-mi-fix-PCIe.patch \
 "
 
 


### PR DESCRIPTION
Reenable PCIe after switching the kernel. Some changes were introduced with the 6.1 kernel, so the DTS nodes were not working any more. Adjusted it according to the imx8mm evk in linux-fslc-imx 5.15