### PR TITLE
i.MX8MM EVA MI: fix UART B hardware flow

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx_5.15.87/0009-arm64-dts-iesy-iesy-imx8mm-osm-sf-fix-UART-B.patch
+++ b/recipes-kernel/linux/linux-fslc-imx_5.15.87/0009-arm64-dts-iesy-iesy-imx8mm-osm-sf-fix-UART-B.patch
@@ -1,0 +1,36 @@
+From d7340c473df7d14e72ab4057922ceb734213cce9 Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Tue, 31 Oct 2023 12:26:37 +0100
+Subject: [PATCH 9/9] arm64: dts: iesy: iesy-imx8mm-osm-sf: fix UART B
+
+Hardware flow was not working properly, fixing it by using gpio rtscts
+---
+ arch/arm64/boot/dts/iesy/iesy-imx8mm-osm-sf.dtsi | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/iesy/iesy-imx8mm-osm-sf.dtsi b/arch/arm64/boot/dts/iesy/iesy-imx8mm-osm-sf.dtsi
+index ff03b0a0838d7..18304bb767d27 100644
+--- a/arch/arm64/boot/dts/iesy/iesy-imx8mm-osm-sf.dtsi
++++ b/arch/arm64/boot/dts/iesy/iesy-imx8mm-osm-sf.dtsi
+@@ -86,7 +86,6 @@ &uart2 { /* UART B */
+ 	status = "okay";
+ 	cts-gpios = <&gpio5 28 GPIO_ACTIVE_LOW>;
+ 	rts-gpios = <&gpio5 29 GPIO_ACTIVE_LOW>;
+-	uart-has-rtscts;
+ };
+ 
+ &uart3 { /* UART Console */
+@@ -376,8 +375,8 @@ pinctrl_uart2: uart2grp {
+ 		fsl,pins = <
+ 			MX8MM_IOMUXC_UART2_RXD_UART2_DCE_RX		0x140
+ 			MX8MM_IOMUXC_UART2_TXD_UART2_DCE_TX		0x140
+-			MX8MM_IOMUXC_UART4_RXD_UART2_DCE_CTS_B	0x140
+-			MX8MM_IOMUXC_UART4_TXD_UART2_DCE_RTS_B	0x140
++			MX8MM_IOMUXC_UART4_RXD_GPIO5_IO28		0x140
++			MX8MM_IOMUXC_UART4_TXD_GPIO5_IO29		0x140
+ 		>;
+ 	};
+ 
+-- 
+2.30.2
+

--- a/recipes-kernel/linux/linux-fslc-imx_5.15.bbappend
+++ b/recipes-kernel/linux/linux-fslc-imx_5.15.bbappend
@@ -10,6 +10,7 @@ SRC_URI += " \
     file://0006-arm64-dts-iesy-iesy-imx8mm-eva-mi-add-SPI-B.patch \
     file://0007-arm64-dts-iesy-iesy-imx8mm-eva-mi-fix-PCIe.patch \
     file://0008-driver-net-phy-config-eth-phy-behavior.patch \
+    file://0009-arm64-dts-iesy-iesy-imx8mm-osm-sf-fix-UART-B.patch \
 "
 
 


### PR DESCRIPTION
hardware flow control not working properly. Fixed by using gpio rtscts