### PR TITLE
RPX30 EVA-MI: separate device tree files for CM006 and BB138a

### DIFF
--- a/recipes-kernel/linux/linux-rockchip_5.10.bbappend
+++ b/recipes-kernel/linux/linux-rockchip_5.10.bbappend
@@ -23,6 +23,7 @@ SRC_URI += " \
 	file://0020-arm64-dts-iesy-enable-i2s-master-clock-and-reduce-i2s-channels.patch \
 	file://0021-arm64-dts-rockchip-add-uio-support-for-header-gpios.patch \
 	file://0022-drivers-rtc-add-support-for-max31343-rtc.patch \
+	file://0023-arm64-dts-rockchip-separate-device-tree-files-for-cm006-and-bb138a.patch \
 "
 
 python () {

--- a/recipes-kernel/linux/linux-rockchip_5.10/0023-arm64-dts-rockchip-separate-device-tree-files-for-cm006-and-bb138a.patch
+++ b/recipes-kernel/linux/linux-rockchip_5.10/0023-arm64-dts-rockchip-separate-device-tree-files-for-cm006-and-bb138a.patch
@@ -1,0 +1,1544 @@
+From 32479f6777626446ad2834304cd4d4999030354b Mon Sep 17 00:00:00 2001
+From: Christian Biermann <bie@iesy.com>
+Date: Tue, 31 Oct 2023 14:19:35 +0100
+Subject: [PATCH 1/1] arm64: dts: rockchip: separate device tree files for
+ CM006 and BB138a
+
+---
+ .../boot/dts/iesy/iesy-rpx30-eva-mi-v2.dts    | 916 ++++++------------
+ .../boot/dts/iesy/iesy-rpx30-osm-sf.dtsi      | 427 ++++++++
+ 2 files changed, 705 insertions(+), 638 deletions(-)
+ create mode 100644 arch/arm64/boot/dts/iesy/iesy-rpx30-osm-sf.dtsi
+
+diff --git a/arch/arm64/boot/dts/iesy/iesy-rpx30-eva-mi-v2.dts b/arch/arm64/boot/dts/iesy/iesy-rpx30-eva-mi-v2.dts
+index 45515d06117e..ab222fe4d266 100644
+--- a/arch/arm64/boot/dts/iesy/iesy-rpx30-eva-mi-v2.dts
++++ b/arch/arm64/boot/dts/iesy/iesy-rpx30-eva-mi-v2.dts
+@@ -6,55 +6,13 @@
+  */
+ 
+ /dts-v1/;
+-#include <dt-bindings/gpio/gpio.h>
+-#include <dt-bindings/pinctrl/rockchip.h>
+ #include <dt-bindings/input/input.h>
+ #include <dt-bindings/display/drm_mipi_dsi.h>
+-#include <dt-bindings/sensor-dev.h>
+ #include <dt-bindings/net/mscc-phy-vsc8531.h>
+-#include "../rockchip/px30.dtsi"
+-#include "../rockchip/rk3326-linux.dtsi"
+-#include <dt-bindings/leds/common.h>
+-
++#include "iesy-rpx30-osm-sf.dtsi"
+ 
+ / {
+ 	model = "iesy RPX30 EVA-MI V2 (Eval Kit)";
+-	compatible = "rockchip,px30-evb-ddr3-v10-linux", "rockchip,px30";
+-
+-	chosen {
+-		bootargs = "earlycon=uart8250,mmio32,0xff160000 console=ttyFIQ0 rw root=PARTUUID=614e0000-0000 rootwait uio_pdrv_genirq.of_id=generic-uio";
+-	};
+-
+-	fiq-debugger {
+-		rockchip,baudrate = <115200>;  /* Only 115200 and 1500000 */
+-		pinctrl-0 = <&uart2m1_xfer>;
+-		status = "okay";
+-	};
+-
+-	charge-animation {
+-		compatible = "rockchip,uboot-charge";
+-		rockchip,uboot-charge-on = <0>;
+-		rockchip,android-charge-on = <1>;
+-		rockchip,uboot-low-power-voltage = <3500>;
+-		rockchip,screen-on-voltage = <3600>;
+-		status = "okay";
+-	};
+-
+-	vcc_phy: vcc-phy-regulator {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc_phy";
+-		regulator-always-on;
+-		regulator-boot-on;
+-	};
+-
+-	vcc5v0_sys: vccsys {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc5v0_sys";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-	};
+ 
+ 	/* regulator for USB OTG port */
+ 	usb_a_vbus_regulator: regulator@1 {
+@@ -100,20 +58,58 @@ vdd3v3_bb138: regulator@4 {
+ 		regulator-boot-on;
+ 	};
+ 
++	/* BB138a: 8 GPIOs on Pin Header */
++	header-gpios {
++		compatible = "generic-uio";
++		linux,uio-name = "header-gpios";
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_gpio_a>;
++	};
++
++	/* BB138a: MAX9867ETJ+ audio codec */
++	max9867-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,name = "rockchip,max9867-codec";
++		simple-audio-card,format = "i2s";
++
++		simple-audio-card,widgets =
++			"Speaker", "Jack";
++		simple-audio-card,routing =
++            "Jack", "LOUT",
++            "Jack", "ROUT";
++
++		simple-audio-card,frame-master = <&cpudai>;
++		simple-audio-card,bitclock-master = <&cpudai>;
++		
++		status = "okay";
++
++		cpudai: simple-audio-card,cpu {
++			sound-dai = <&i2s1_2ch>;
++			dai-tdm-slot-num = <1>;
++			dai-tdm-slot-width = <16>;
++		};
++
++		simple-audio-card,codec {
++			sound-dai = <&max9867>;
++			clocks = <&cru SCLK_I2S1_OUT>;
++		};
++	};
++
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
+ 		pinctrl-names = "default";
+         pinctrl-0 = <&pinctrl_leds_bb138>; 
+ 
+-		/* green user led (LD4) on BB138 */
++		/* BB138a: green user led (LD4) */
+ 		led@0 {
+ 			label = "USER_LED_00";
+ 			gpios = <&gpio3 RK_PA0 GPIO_ACTIVE_LOW>;
+ 			linux,default-trigger = "heartbeat";
+ 		};
+ 
+-		/* yellow user led (LD9)) on BB138 */
++		/* BB138a: yellow user led (LD9)) */
+ 		led@1 {
+ 			label = "USER_LED_01";
+ 			gpios = <&gpio3 RK_PA1 GPIO_ACTIVE_LOW>;
+@@ -130,66 +126,146 @@ user-buttons {
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&pinctrl_buttons>;
+ 
++		/* BB138a: User-Button 1 */
+         user-button-1 {
+             label = "User Button 1";
+             gpios = <&gpio3 RK_PA2 GPIO_ACTIVE_LOW>;
+             linux,code = <KEY_X>;
+         };
+ 
++		/* BB138a: User-Button 2 */
+         user-button-2 {
+             label = "User Button 2";
+             gpios = <&gpio3 RK_PA3 GPIO_ACTIVE_LOW>;
+             linux,code = <KEY_Z>;
+         };
+ 	};
++};
+ 
+-	header-gpios {
+-		compatible = "generic-uio";
+-		linux,uio-name = "header-gpios";
++&gmac {
++	phy-supply = <&vcc_phy>;
++	phy-handle = <&gmac0_phy>;
++	clock_in_out = "input";
++	assigned-clocks = <&cru SCLK_GMAC>;
++	assigned-clock-parents = <&cru SCLK_GMAC>;
++	status = "okay";
+ 
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pinctrl_gpio_a>;
+-	};
++	gmdio0: gmac0_mdio {
++		compatible = "snps,dwmac-mdio";
+ 
+-	max9867-sound {
+-		compatible = "simple-audio-card";
+-		simple-audio-card,name = "rockchip,max9867-codec";
+-		simple-audio-card,format = "i2s";
++		#address-cells = <1>;
++		#size-cells = <0>;
+ 
+-		simple-audio-card,widgets =
+-			"Speaker", "Jack";
+-		simple-audio-card,routing =
+-            "Jack", "LOUT",
+-            "Jack", "ROUT";
++		/* BB138a: Ethernet PHY */
++		gmac0_phy: ethernet-phy@0 {
++			//compatible = "ethernet-phy-id0007.0770";
++			reg = <0x0>;
++			max-speed = <100>;
++			vsc8531,vddmac = <1800>;
++			vsc8531,edge-slowdown = <76>;
++			vsc8531,led-0-mode = <VSC8531_LINK_100_ACTIVITY>;
++			vsc8531,led-1-mode = <VSC8531_LINK_100_ACTIVITY>;
++		};
++	};
++};
+ 
+-		simple-audio-card,frame-master = <&cpudai>;
+-		simple-audio-card,bitclock-master = <&cpudai>;
+-		
+-		status = "okay";
++&u2phy {
++	status = "okay";
+ 
+-		cpudai: simple-audio-card,cpu {
+-			sound-dai = <&i2s1_2ch>;
+-			dai-tdm-slot-num = <1>;
+-			dai-tdm-slot-width = <16>;
+-		};
++	/* BB138a: USB2.0 Host PHY */
++	u2phy_host: host-port {
++		phy-supply = <&vcc3v0_pmu>;
++		vbus-supply = <&usb_b_vbus_regulator>;
++		status = "okay";
++		pinctrl-0 = <&u2phy_host_pin>;
++	};
+ 
+-		simple-audio-card,codec {
+-			sound-dai = <&max9867>;
+-			clocks = <&cru SCLK_I2S1_OUT>;
+-		};
++	/* BB138a: USB2.0 OTG PHY */
++	u2phy_otg: otg-port {
++		phy-supply = <&vcc3v0_pmu>;
++		vbus-supply = <&usb_a_vbus_regulator>;
++		status = "okay";
++		pinctrl-0 = <&u2phy_otg_pin>;
+ 	};
+ };
+ 
+-&cpu0 {
++&usb20_otg {
++    /*vbus-supply = <&usb_a_vbus_regulator>;*/
++    dr_mode = "otg";
++	status = "okay";
++
+ 	/* should be defined to avoid kernel log error */
+-	/* but no further info about cpu power_model available */
+-	/* power_model = <?>; */
++	/* vusb_d: digital usb supply, 1.2V */
++	/* vusb_q: analog usb supply, 1.1V */
++	/* no further info available */
++	/* vusb_d-supply = <???>; */
++	/* vusb_a-supply = <???>; */
++};
++
++&usb_host0_ehci {
++    /*vbus-supply = <&usb_b_vbus_regulator>;*/
++	status = "okay";
++};
++
++&usb_host0_ohci {
++    /*vbus-supply = <&usb_b_vbus_regulator>;*/
++	status = "okay";
+ };
+ 
+ &display_subsystem {
+ 	status = "okay";
+ };
+ 
++/* ARM Mali GPU */
++&gpu {
++	mali-supply = <&vdd_logic>;
++	shadercores-supply = <&vdd_logic>;
++	status = "okay";
++};
++
++/* Big Video Output Processor (VOPB) */
++&vopb {
++	status = "okay";
++};
++
++&vopb_mmu {
++	status = "okay";
++};
++
++/* Little Video Output Processor (VOPL) */
++&vopl {
++	status = "disabled";
++};
++
++&vopl_mmu {
++	status = "disabled";
++};
++
++/* Video Decoder Processing Unit (VDPU) */
++//&vdpu {
++//	status = "okay";
++//};
++
++/* Video Encoder Processing Unit (VEPU) */
++//&vepu {
++//	status = "okay";
++//};
++
++//&vpu_mmu {
++//	status = "okay";
++//};
++
++/* Media Process Platform (MPP) */
++//&mpp_srv {
++//	status = "okay";
++//};
++
++/* Raster Graphics Accelerator (RGA) */
++//&rk_rga {
++//	status = "okay";
++//};
++
++/* Display Serial Interface */
+ &dsi {
+ 	status = "disabled";
+ 	rockchip,lane-rate = <891>;
+@@ -289,73 +365,84 @@ &dsi_in_vopl {
+ 	status = "disabled";
+ };
+ 
+-/* what's this? */
+-//&bus_apll {
+-//	bus-supply = <&vdd_logic>;
++&video_phy {
++	/* should be defined to avoid kernel log error */
++	/* no further info about video phy supply available */
++	/* phy-supply = "???"; */
++	status = "okay";
++};
++
++/* HEVC video decoder */
++//&hevc {
++//	status = "okay";
++//};
++
++//&hevc_mmu {
+ //	status = "okay";
+ //};
+ 
+-&cpu0 {
+-	cpu-supply = <&vdd_arm>;
++/* BB138a: UART_A on MicroBus and Pin Header */
++&uart0 {
++	status = "okay";
+ };
+ 
+-/* DDR PHY Interface - used for DDR monitoring */
+-&dfi {
++/* BB138a: UART_B M.2 socket (not used) */
++&uart1 {
+ 	status = "okay";
+ };
+ 
+-/* Dynamic Memory Controller */
+-&dmc {
+-	center-supply = <&vdd_logic>;
+-	auto-freq-en = <0>;
++/* BB138a: PWM outputs on Pin Header */
++&pwm0 {
+ 	status = "okay";
+ };
+ 
+-/* eMMC on CM006 */
+-&emmc {
+-	bus-width = <8>;
+-	cap-mmc-highspeed;
+-	/* mmc-ddr-1_8v; */
+-	mmc-hs200-1_8v;
+-	supports-emmc;
+-	disable-wp;
+-	non-removable;
+-	num-slots = <1>;
++&pwm1 {
+ 	status = "okay";
++};
+ 
+-	vmmc-supply = <&vcc3v3_sys>;
+-	vqmmc-supply = <&vcc1v8_soc>;
++&pwm2 {
++	status = "okay";
+ };
+ 
+-&gmac {
+-	phy-supply = <&vcc_phy>;
+-	phy-handle = <&gmac0_phy>;
+-	clock_in_out = "input";
+-	assigned-clocks = <&cru SCLK_GMAC>;
+-	assigned-clock-parents = <&cru SCLK_GMAC>;
++&pwm3 {
+ 	status = "okay";
++};
+ 
+-	gmdio0: gmac0_mdio {
+-		compatible = "snps,dwmac-mdio";
++/* BB138a: SAR ADC inputs */
++&saradc {
++	status = "okay";
++	vref-supply = <&vcc1v8_soc>;
++};
+ 
+-		#address-cells = <1>;
+-		#size-cells = <0>;
++/* Temperature Sensor SDC (used for reading gpu temperature) */
++//&tsadc {
++//	pinctrl-names = "gpio", "otpout";
++//	pinctrl-0 = <&tsadc_otp_gpio>;
++//	pinctrl-1 = <&tsadc_otp_out>;
++//	status = "okay";
++//};
+ 
+-		gmac0_phy: ethernet-phy@0 {
+-			//compatible = "ethernet-phy-id0007.0770";
+-			reg = <0x0>;
+-			max-speed = <100>;
+-			vsc8531,vddmac = <1800>;
+-			vsc8531,edge-slowdown = <76>;
+-			vsc8531,led-0-mode = <VSC8531_LINK_100_ACTIVITY>;
+-			vsc8531,led-1-mode = <VSC8531_LINK_100_ACTIVITY>;
+-		};
+-	};
+-};
++/* NAND Flash Controller */
++//&nandc0 {
++//	status = "okay";
++//};
+ 
+-&gpu {
+-	mali-supply = <&vdd_logic>;
+-	shadercores-supply = <&vdd_logic>;
++/* BB138a: SD card connector */
++&sdmmc {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	supports-sd;
++	card-detect-delay = <800>;
++	ignore-pm-notify;
++	/*cd-gpios = <&gpio2 4 GPIO_ACTIVE_HIGH>; [> CD GPIO <]*/
++	sd-uhs-sdr12;
++	sd-uhs-sdr25;
++	sd-uhs-sdr50;
++	sd-uhs-sdr104;
++	max-frequency = <135000000>;
++	vqmmc-supply = <&vccio_sd>;
++	vmmc-supply = <&vdd3v3_bb138>;
+ 	status = "okay";
+ };
+ 
+@@ -366,281 +453,21 @@ &i2s1_2ch {
+ };
+ 
+ &i2c0 {
+-	status = "okay";
+-
+-	/* Power Management IC */
+-	rk809: pmic@20 {
+-		compatible = "rockchip,rk809";
+-		reg = <0x20>;
+-		interrupt-parent = <&gpio0>;
+-		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
+-		pinctrl-names = "default", "pmic-sleep",
+-				"pmic-power-off", "pmic-reset";
+-		pinctrl-0 = <&pmic_int>;
+-		pinctrl-1 = <&soc_slppin_slp>, <&rk817_slppin_slp>;
+-		pinctrl-2 = <&soc_slppin_gpio>, <&rk817_slppin_pwrdn>;
+-		pinctrl-3 = <&soc_slppin_rst>, <&rk817_slppin_rst>;
+-		rockchip,system-power-controller;
+-		wakeup-source;
+-		#clock-cells = <1>;
+-		clock-output-names = "rk808-clkout1", "rk808-clkout2";
+-		//fb-inner-reg-idxs = <2>;
+-		/* 1: rst regs (default in codes), 0: rst the pmic */
+-		pmic-reset-func = <1>;
+-
+-		vcc1-supply = <&vcc5v0_sys>;
+-		vcc2-supply = <&vcc5v0_sys>;
+-		vcc3-supply = <&vcc5v0_sys>;
+-		vcc4-supply = <&vcc5v0_sys>;
+-		vcc5-supply = <&vcc3v3_sys>;
+-		vcc6-supply = <&vcc5v0_sys>;
+-		vcc7-supply = <&vcc3v3_sys>;
+-		vcc8-supply = <&vcc5v0_sys>;
+-		vcc9-supply = <&vcc5v0_sys>;
+-
+-		pwrkey {
+-			status = "okay";
+-		};
+-
+-		pinctrl_rk8xx: pinctrl_rk8xx {
+-			gpio-controller;
+-			#gpio-cells = <2>;
+-
+-			rk817_slppin_null: rk817_slppin_null {
+-				pins = "gpio_slp";
+-				function = "pin_fun0";
+-			};
+-
+-			rk817_slppin_slp: rk817_slppin_slp {
+-				pins = "gpio_slp";
+-				function = "pin_fun1";
+-			};
+-
+-			rk817_slppin_pwrdn: rk817_slppin_pwrdn {
+-				pins = "gpio_slp";
+-				function = "pin_fun2";
+-			};
+-
+-			rk817_slppin_rst: rk817_slppin_rst {
+-				pins = "gpio_slp";
+-				function = "pin_fun3";
+-			};
+-		};
+-
+-		regulators {
+-			vdd_logic: DCDC_REG1 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <900000>;
+-				regulator-max-microvolt = <1100000>;
+-				regulator-ramp-delay = <6001>;
+-				regulator-initial-mode = <0x2>;
+-				regulator-name = "vdd_logic";
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <950000>;
+-				};
+-			};
+-
+-			vdd_arm: DCDC_REG2 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <950000>;
+-				regulator-max-microvolt = <1350000>;
+-				regulator-ramp-delay = <6001>;
+-				regulator-initial-mode = <0x2>;
+-				regulator-name = "vdd_arm";
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <950000>;
+-				};
+-			};
+-
+-			vcc_ddr: DCDC_REG3 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-name = "vcc_ddr";
+-				regulator-initial-mode = <0x2>;
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-				};
+-			};
+-			/*
+-			vcc_3v0: DCDC_REG4 {
+-				regulator-min-microvolt = <3000000>;
+-				regulator-max-microvolt = <3000000>;
+-				regulator-initial-mode = <0x2>;
+-				regulator-name = "vcc_3v0";
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <3000000>;
+-				};
+-			};*/
+-
+-			vcc3v3_sys: DCDC_REG5 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <3300000>;
+-				regulator-max-microvolt = <3300000>;
+-				regulator-name = "vcc3v3_sys";
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <3300000>;
+-				};
+-			};
+-
+-			vcc_1v0: LDO_REG1 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1000000>;
+-				regulator-max-microvolt = <1000000>;
+-				regulator-name = "vcc_1v0";
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <1000000>;
+-				};
+-			};
+-
+-			vcc1v8_soc: LDO_REG2 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-
+-				regulator-name = "vcc1v8_soc";
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <1800000>;
+-				};
+-			};
+-
+-			vdd1v0_soc: LDO_REG3 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1000000>;
+-				regulator-max-microvolt = <1000000>;
+-
+-				regulator-name = "vcc1v0_soc";
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <1000000>;
+-				};
+-			};
+-
+-			vcc3v0_pmu: LDO_REG4 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <3300000>;
+-				regulator-max-microvolt = <3300000>;
+-
+-				regulator-name = "vcc3v0_pmu";
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <3300000>;
+-
+-				};
+-			};
+-
+-			vccio_sd: LDO_REG5 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <3300000>;
+-
+-				regulator-name = "vccio_sd";
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <3300000>;
+-				};
+-			};
+-			/*
+-			vcc_sd: LDO_REG6 {
+-				regulator-min-microvolt = <3300000>;
+-				regulator-max-microvolt = <3300000>;
+-
+-				regulator-name = "vcc_sd";
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <3300000>;
+-
+-				};
+-			};*/
+-
+-			vcc2v8_dvp: LDO_REG7 {
+-				regulator-min-microvolt = <2800000>;
+-				regulator-max-microvolt = <2800000>;
+-
+-				regulator-name = "vcc2v8_dvp";
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <2800000>;
+-				};
+-			};
+-
+-			vcc1v8_dvp: LDO_REG8 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-
+-				regulator-name = "vcc1v8_dvp";
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <1800000>;
+-				};
+-			};
+-
+-			vdd1v5_dvp: LDO_REG9 {
+-				regulator-min-microvolt = <1500000>;
+-				regulator-max-microvolt = <1500000>;
+-
+-				regulator-name = "vdd1v5_dvp";
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <1500000>;
+-				};
+-			};
+-
+-			vcc5v0_host: SWITCH_REG1 {
+-				regulator-name = "vcc5v0_host";
+-			};
+-
+-			vcc3v3_lcd: SWITCH_REG2 {
+-				regulator-name = "vcc3v3_lcd";
+-			};
+-		};
+-	};
+-
+-	/* LM75 sensor on BB138 */
++	/* BB138a: LM75 sensor */
+ 	sensor@4e {
+ 		status = "okay";
+ 		compatible = "lm75";
+ 		reg = <0x4e>;
+ 	};
+ 
+-	/* RTC on BB138 */
++	/* BB138a: PFC85263 RTC */
+ 	rtc@51 {
+ 		status = "okay";
+ 		compatible = "nxp,pcf85263";
+ 		reg = <0x51>;
+ 	};
+ 
+-	/* RTC on CM006 REV3.00 */
+-	rtc@68 {
+-		status = "okay";
+-		compatible = "adi,max31343";
+-		reg = <0x68>;
+-	};
+-
+-	/* EEPROM on CM006 */
+-	eeprom@50 {
+-		status = "okay";
+-		compatible = "atmel,24c32";
+-		reg = <0x50>;
+-		pagesize = <32>;
+-	};
+-
+-	/* EEPROM on BB138 */
++	/* BB138a: AT24C64D EEPROM */
+ 	eeprom@53 {
+ 		status = "okay";
+ 		compatible = "atmel,24c64";
+@@ -652,6 +479,7 @@ eeprom@53 {
+ &i2c1 {
+ 	status = "okay";
+ 
++	/* BB138a: HDMI to MIPI converter */
+ 	lt8912@48 {
+         compatible = "lontium,lt8912";
+         reg = <0x48>;
+@@ -685,6 +513,7 @@ timing0: timing0 {
+ */
+     };
+ 
++	/* BB138a: MAX9867ETJ+ audio codec */
+ 	max9867: audio_codec@18 {
+ 		#sound-dai-cells = <0>;
+ 		compatible = "maxim,max9867";
+@@ -824,18 +653,62 @@ mode2 { // IMX219_MODE_640X480
+             line_length = "3559";
+             dpcm_enable = "false";
+ 
+-            min_gain_val = "1";
+-            max_gain_val = "16";
+-            min_hdr_ratio = "1";
+-            max_hdr_ratio = "64";
+-            min_framerate = "1";
+-            max_framerate = "90";
+-            min_exp_time = "11";
+-          max_exp_time = "358731";
+-            embedded_metadata_height = "0";
+-        };
++            min_gain_val = "1";
++            max_gain_val = "16";
++            min_hdr_ratio = "1";
++            max_hdr_ratio = "64";
++            min_framerate = "1";
++            max_framerate = "90";
++            min_exp_time = "11";
++          max_exp_time = "358731";
++            embedded_metadata_height = "0";
++        };
++	};
++
++};
++
++&spi0 {
++	status = "okay";
++
++    spidev@0 {
++       compatible = "linux,spidev";
++       spi-max-frequency = <10000000>;
++	   reg = <0>;
++	};
++
++    spidev@1 {
++       compatible = "linux,spidev";
++       spi-max-frequency = <10000000>;
++	   reg = <1>;
++	};
++};
++
++&spi1 {
++	status = "okay";
++
++	// next line only for CM006 REV1.00
++	cs-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_LOW>;
++
++    spidev@0 {
++       compatible = "linux,spidev";
++       spi-max-frequency = <10000000>;
++	   reg = <0>;
++	};
++
++    spidev@1 {
++       compatible = "linux,spidev";
++       spi-max-frequency = <10000000>;
++	   reg = <1>;
+ 	};
++};
+ 
++&power {
++	pd_vi-supply = <&vdd_logic>;
++	pd_vpu-supply = <&vdd_logic>;
++	pd_gpu-supply = <&vdd_logic>;
++	pd_usb-supply = <&vdd_logic>;
++	pd_mmc_nand-supply = <&vdd_logic>;
++	pd_vo-supply = <&vdd_logic>;
+ };
+ 
+ &io_domains {
+@@ -852,6 +725,14 @@ &io_domains {
+ 	//vccio-oscgpi-supply = <???>;
+ };
+ 
++&pmu_io_domains {
++	status = "okay";
++
++	pmuio1-supply = <&vcc3v0_pmu>;
++	//pmuio2-supply = <&vcc3v0_pmu>;
++	pmuio2-supply = <&vcc1v8_soc>;
++};
++
+ //&isp_mmu {
+ //	status = "okay";
+ //};
+@@ -890,38 +771,7 @@ dphy_rx0_out: endpoint@0 {
+ };
+ */
+ 
+-//&nandc0 {
+-//	status = "okay";
+-//};
+-
+-&pmu_io_domains {
+-	status = "okay";
+-
+-	pmuio1-supply = <&vcc3v0_pmu>;
+-	//pmuio2-supply = <&vcc3v0_pmu>;
+-	pmuio2-supply = <&vcc1v8_soc>;
+-};
+-
+-&pwm0 {
+-	status = "okay";
+-};
+-
+-&pwm1 {
+-	status = "okay";
+-};
+-
+-&pwm2 {
+-	status = "okay";
+-};
+-
+-&pwm3 {
+-	status = "okay";
+-};
+-
+-//&rk_rga {
+-//	status = "okay";
+-//};
+-
++/* Rockchip Image Signal Processing (ISP) */
+ //&rkisp1 {
+ //	status = "okay";
+ //
+@@ -941,186 +791,6 @@ &pwm3 {
+ //	rockchip,sleep-debug-en = <1>;
+ //};
+ 
+-/* 2 SAR ADC inputs on BB138 */
+-&saradc {
+-	status = "okay";
+-	vref-supply = <&vcc1v8_soc>;
+-};
+-
+-/* SD card connector on BB138 */
+-&sdmmc {
+-	bus-width = <4>;
+-	cap-mmc-highspeed;
+-	cap-sd-highspeed;
+-	supports-sd;
+-	card-detect-delay = <800>;
+-	ignore-pm-notify;
+-	/*cd-gpios = <&gpio2 4 GPIO_ACTIVE_HIGH>; [> CD GPIO <]*/
+-	sd-uhs-sdr12;
+-	sd-uhs-sdr25;
+-	sd-uhs-sdr50;
+-	sd-uhs-sdr104;
+-	max-frequency = <135000000>;
+-	vqmmc-supply = <&vccio_sd>;
+-	vmmc-supply = <&vdd3v3_bb138>;
+-	status = "okay";
+-};
+-
+-/* used for reading gpu temperature */
+-//&tsadc {
+-//	pinctrl-names = "gpio", "otpout";
+-//	pinctrl-0 = <&tsadc_otp_gpio>;
+-//	pinctrl-1 = <&tsadc_otp_out>;
+-//	status = "okay";
+-//};
+-
+-&grf {
+-	io_domains: io-domains {
+-		/* should be defined to avoid kernel log error */
+-		/* but no further info about vccio-oscgpi for PX30 available */
+-		/* vccio-oscgpi-supply = <???>; */
+-	};
+-};
+-
+-&uart0 {
+-	status = "okay";
+-};
+-
+-&uart1 {
+-	status = "okay";
+-};
+-
+-&u2phy {
+-	status = "okay";
+-
+-	u2phy_host: host-port {
+-		phy-supply = <&vcc3v0_pmu>;
+-		vbus-supply = <&usb_b_vbus_regulator>;
+-		status = "okay";
+-		pinctrl-0 = <&u2phy_host_pin>;
+-	};
+-
+-	u2phy_otg: otg-port {
+-		phy-supply = <&vcc3v0_pmu>;
+-		vbus-supply = <&usb_a_vbus_regulator>;
+-		status = "okay";
+-		pinctrl-0 = <&u2phy_otg_pin>;
+-	};
+-};
+-
+-//&video_phy {
+-	/* should be defined to avoid kernel log error */
+-	/* no further info about video phy supply available */
+-	/* phy-supply = "???"; */
+-//};
+-
+-&usb20_otg {
+-    /*vbus-supply = <&usb_a_vbus_regulator>;*/
+-    dr_mode = "otg";
+-	status = "okay";
+-
+-	/* should be defined to avoid kernel log error */
+-	/* vusb_d: digital usb supply, 1.2V */
+-	/* vusb_q: analog usb supply, 1.1V */
+-	/* no further info available */
+-	/* vusb_d-supply = <???>; */
+-	/* vusb_a-supply = <???>; */
+-};
+-
+-&usb_host0_ehci {
+-    /*vbus-supply = <&usb_b_vbus_regulator>;*/
+-	status = "okay";
+-};
+-
+-&usb_host0_ohci {
+-    /*vbus-supply = <&usb_b_vbus_regulator>;*/
+-	status = "okay";
+-};
+-
+-&vopb {
+-	status = "okay";
+-};
+-
+-&vopb_mmu {
+-	status = "okay";
+-};
+-
+-&vopl {
+-	status = "disabled";
+-};
+-
+-&vopl_mmu {
+-	status = "disabled";
+-};
+-
+-//&mpp_srv {
+-//	status = "okay";
+-//};
+-
+-//&vdpu {
+-//	status = "okay";
+-//};
+-
+-//&vepu {
+-//	status = "okay";
+-//};
+-
+-//&vpu_mmu {
+-//	status = "okay";
+-//};
+-
+-//&hevc {
+-//	status = "okay";
+-//};
+-
+-//&hevc_mmu {
+-//	status = "okay";
+-//};
+-
+-&spi0 {
+-	status = "okay";
+-
+-    spidev@0 {
+-       compatible = "linux,spidev";
+-       spi-max-frequency = <10000000>;
+-	   reg = <0>;
+-	};
+-
+-    spidev@1 {
+-       compatible = "linux,spidev";
+-       spi-max-frequency = <10000000>;
+-	   reg = <1>;
+-	};
+-};
+-
+-&spi1 {
+-	status = "okay";
+-
+-	// next line only for CM006 REV1.00
+-	cs-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_LOW>;
+-
+-    spidev@0 {
+-       compatible = "linux,spidev";
+-       spi-max-frequency = <10000000>;
+-	   reg = <0>;
+-	};
+-
+-    spidev@1 {
+-       compatible = "linux,spidev";
+-       spi-max-frequency = <10000000>;
+-	   reg = <1>;
+-	};
+-};
+-
+-&power {
+-	pd_vi-supply = <&vdd_logic>;
+-	pd_vpu-supply = <&vdd_logic>;
+-	pd_gpu-supply = <&vdd_logic>;
+-	pd_usb-supply = <&vdd_logic>;
+-	pd_mmc_nand-supply = <&vdd_logic>;
+-	pd_vo-supply = <&vdd_logic>;
+-};
+-
+ &pinctrl {
+ 	headphone {
+ 		hp_det: hp-det {
+@@ -1128,28 +798,6 @@ hp_det: hp-det {
+ 		};
+ 	};
+ 
+-	pmic {
+-		pmic_int: pmic_int {
+-			rockchip,pins =
+-				<0 RK_PA7 RK_FUNC_GPIO &pcfg_pull_up>;
+-		};
+-
+-		soc_slppin_gpio: soc_slppin_gpio {
+-			rockchip,pins =
+-				<0 RK_PA4 RK_FUNC_GPIO &pcfg_output_low>;
+-		};
+-
+-		soc_slppin_slp: soc_slppin_slp {
+-			rockchip,pins =
+-				<0 RK_PA4 1 &pcfg_pull_none>;
+-		};
+-
+-		soc_slppin_rst: soc_slppin_rst {
+-			rockchip,pins =
+-				<0 RK_PA4 2 &pcfg_pull_none>;
+-		};
+-	};
+-
+ 	leds {
+ 		pinctrl_leds_bb138: pinctrl-leds-bb138 {
+ 			rockchip,pins = <3 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none
+@@ -1221,13 +869,6 @@ uart1_rts: uart1-rts {
+ 		};
+ 	};
+ 
+-	uart2-m1 {
+-		uart2m1_xfer: uart2m1-xfer {
+-			rockchip,pins =
+-				<2 RK_PB4 2 &pcfg_pull_up>,
+-				<2 RK_PB6 2 &pcfg_pull_up_2ma>;
+-		};
+-	};
+ 	// This Pin configuration disables the eth0 capabilities
+ 	// gmac {
+ 	// 	rmii_pins: rmii-pins {
+@@ -1352,4 +993,3 @@ u2phy_otg_pin: otg-port {
+ /* DON'T PUT ANYTHING BELOW HERE.  PUT IT ABOVE PINCTRL */
+ /* DON'T PUT ANYTHING BELOW HERE.  PUT IT ABOVE PINCTRL */
+ /* DON'T PUT ANYTHING BELOW HERE.  PUT IT ABOVE PINCTRL */
+-
+diff --git a/arch/arm64/boot/dts/iesy/iesy-rpx30-osm-sf.dtsi b/arch/arm64/boot/dts/iesy/iesy-rpx30-osm-sf.dtsi
+new file mode 100644
+index 000000000000..1d0de6bbc834
+--- /dev/null
++++ b/arch/arm64/boot/dts/iesy/iesy-rpx30-osm-sf.dtsi
+@@ -0,0 +1,427 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Device Tree for iesy RPX30 OSM SF (OSM Module)
++ *
++ * Copyright (c) 2023 iesy GmbH
++ */
++
++#include "../rockchip/px30.dtsi"
++
++/ {
++	model = "iesy RPX30 OSM SF (OSM Module)";
++	compatible = "rockchip,px30-evb-ddr3-v10-linux", "rockchip,px30";
++
++	aliases {
++		mmc0 = &emmc;
++		mmc1 = &sdmmc;
++		mmc2 = &sdio;
++	};
++
++	chosen {
++		bootargs = "earlycon=uart8250,mmio32,0xff160000 console=ttyFIQ0 rw root=PARTUUID=614e0000-0000 rootwait uio_pdrv_genirq.of_id=generic-uio";
++	};
++
++	fiq-debugger {
++		compatible = "rockchip,fiq-debugger";
++		rockchip,serial-id = <2>;
++		rockchip,wake-irq = <0>;
++		/* If enable uart uses irq instead of fiq */
++		rockchip,irq-mode-enable = <1>;
++		rockchip,baudrate = <115200>;  /* Only 115200 and 1500000 */
++		interrupts = <GIC_SPI 127 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&uart2m1_xfer>;
++		status = "okay";
++	};
++
++	charge-animation {
++		compatible = "rockchip,uboot-charge";
++		rockchip,uboot-charge-on = <0>;
++		rockchip,android-charge-on = <1>;
++		rockchip,uboot-low-power-voltage = <3500>;
++		rockchip,screen-on-voltage = <3600>;
++		status = "okay";
++	};
++
++	vcc_phy: vcc-phy-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_phy";
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	vcc5v0_sys: vccsys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu0_opp_table {
++	rockchip,avs = <1>;
++};
++
++/* Clock and Reset Unit: ARM PLL */
++//&bus_apll {
++//	bus-supply = <&vdd_logic>;
++//	status = "okay";
++//};
++
++/* DDR PHY Interface - used for DDR monitoring */
++&dfi {
++	status = "okay";
++};
++
++/* Rockchip General Register File (GRF) */
++&grf {
++	io_domains: io-domains {
++		/* should be defined to avoid kernel log error */
++		/* but no further info about vccio-oscgpi for PX30 available */
++		/* vccio-oscgpi-supply = <???>; */
++	};
++};
++
++/* Dynamic Memory Controller */
++&dmc {
++	center-supply = <&vdd_logic>;
++	auto-freq-en = <0>;
++	status = "okay";
++};
++
++&rng {
++	status = "okay";
++};
++
++/* eMMC on CM006 */
++&emmc {
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	/* mmc-ddr-1_8v; */
++	mmc-hs200-1_8v;
++	supports-emmc;
++	disable-wp;
++	non-removable;
++	num-slots = <1>;
++	status = "okay";
++
++	vmmc-supply = <&vcc3v3_sys>;
++	vqmmc-supply = <&vcc1v8_soc>;
++};
++
++&i2c0 {
++   	status = "okay";
++
++	/* Power Management IC */
++	rk809: pmic@20 {
++		compatible = "rockchip,rk809";
++		reg = <0x20>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default", "pmic-sleep",
++				"pmic-power-off", "pmic-reset";
++		pinctrl-0 = <&pmic_int>;
++		pinctrl-1 = <&soc_slppin_slp>, <&rk817_slppin_slp>;
++		pinctrl-2 = <&soc_slppin_gpio>, <&rk817_slppin_pwrdn>;
++		pinctrl-3 = <&soc_slppin_rst>, <&rk817_slppin_rst>;
++		rockchip,system-power-controller;
++		wakeup-source;
++		#clock-cells = <1>;
++		clock-output-names = "rk808-clkout1", "rk808-clkout2";
++		//fb-inner-reg-idxs = <2>;
++		/* 1: rst regs (default in codes), 0: rst the pmic */
++		pmic-reset-func = <1>;
++
++		vcc1-supply = <&vcc5v0_sys>;
++		vcc2-supply = <&vcc5v0_sys>;
++		vcc3-supply = <&vcc5v0_sys>;
++		vcc4-supply = <&vcc5v0_sys>;
++		vcc5-supply = <&vcc3v3_sys>;
++		vcc6-supply = <&vcc5v0_sys>;
++		vcc7-supply = <&vcc3v3_sys>;
++		vcc8-supply = <&vcc5v0_sys>;
++		vcc9-supply = <&vcc5v0_sys>;
++
++		pwrkey {
++			status = "okay";
++		};
++
++		pinctrl_rk8xx: pinctrl_rk8xx {
++			gpio-controller;
++			#gpio-cells = <2>;
++
++			rk817_slppin_null: rk817_slppin_null {
++				pins = "gpio_slp";
++				function = "pin_fun0";
++			};
++
++			rk817_slppin_slp: rk817_slppin_slp {
++				pins = "gpio_slp";
++				function = "pin_fun1";
++			};
++
++			rk817_slppin_pwrdn: rk817_slppin_pwrdn {
++				pins = "gpio_slp";
++				function = "pin_fun2";
++			};
++
++			rk817_slppin_rst: rk817_slppin_rst {
++				pins = "gpio_slp";
++				function = "pin_fun3";
++			};
++		};
++
++		regulators {
++            /* SW1: 1V0 LOG */
++			vdd_logic: DCDC_REG1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <900000>;
++				regulator-max-microvolt = <1100000>;
++				regulator-ramp-delay = <6001>;
++				regulator-initial-mode = <0x2>;
++				regulator-name = "vdd_logic";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <950000>;
++				};
++			};
++
++            /* SW2: 1V0 ARM */
++			vdd_arm: DCDC_REG2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <950000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++				regulator-initial-mode = <0x2>;
++				regulator-name = "vdd_arm";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <950000>;
++				};
++			};
++
++            /* SW3: 1V2 DDR */
++			vcc_ddr: DCDC_REG3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vcc_ddr";
++				regulator-initial-mode = <0x2>;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++            /* SW4: unused */
++			/*
++			vcc_3v0: DCDC_REG4 {
++				regulator-min-microvolt = <3000000>;
++				regulator-max-microvolt = <3000000>;
++				regulator-initial-mode = <0x2>;
++				regulator-name = "vcc_3v0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <3000000>;
++				};
++			};*/
++
++            /* SW5: 3V3 IO */
++			vcc3v3_sys: DCDC_REG5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc3v3_sys";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++            /* LDO1: 1V0 LDO1 */
++			vcc_1v0: LDO_REG1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1000000>;
++				regulator-max-microvolt = <1000000>;
++				regulator-name = "vcc_1v0";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++
++            /* LDO2: 1V8 IO1 */
++			vcc1v8_soc: LDO_REG2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-name = "vcc1v8_soc";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++            /* LDO3: 1V0 LDO3 */
++			vdd1v0_soc: LDO_REG3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1000000>;
++				regulator-max-microvolt = <1000000>;
++
++				regulator-name = "vcc1v0_soc";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++
++            /* LDO4: 3V3 PMU */
++			vcc3v0_pmu: LDO_REG4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-name = "vcc3v0_pmu";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++
++				};
++			};
++
++            /* LDO5: VCC SD */
++			vccio_sd: LDO_REG5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-name = "vccio_sd";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++            /* LDO6: unused */
++			/*
++			vcc_sd: LDO_REG6 {
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-name = "vcc_sd";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++
++				};
++			};*/
++
++            /* LDO7: unused */
++			vcc2v8_dvp: LDO_REG7 {
++				regulator-min-microvolt = <2800000>;
++				regulator-max-microvolt = <2800000>;
++
++				regulator-name = "vcc2v8_dvp";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <2800000>;
++				};
++			};
++
++            /* LDO8: 1V8 IO2 */
++			vcc1v8_dvp: LDO_REG8 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-name = "vcc1v8_dvp";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++            /* LDO9: unused */
++			vdd1v5_dvp: LDO_REG9 {
++				regulator-min-microvolt = <1500000>;
++				regulator-max-microvolt = <1500000>;
++
++				regulator-name = "vdd1v5_dvp";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <1500000>;
++				};
++			};
++
++			vcc5v0_host: SWITCH_REG1 {
++				regulator-name = "vcc5v0_host";
++			};
++
++			vcc3v3_lcd: SWITCH_REG2 {
++				regulator-name = "vcc3v3_lcd";
++			};
++		};
++	};
++
++	/* RTC on CM006 REV3.00 */
++	rtc@68 {
++		status = "okay";
++		compatible = "adi,max31343";
++		reg = <0x68>;
++	};
++
++    /* CAT24C32 EEPROM on CM006 */
++	eeprom@50 {
++		status = "okay";
++		compatible = "atmel,24c32";
++		reg = <0x50>;
++		pagesize = <32>;
++	};
++};
++
++&pinctrl {
++	pmic {
++		pmic_int: pmic_int {
++			rockchip,pins =
++				<0 RK_PA7 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		soc_slppin_gpio: soc_slppin_gpio {
++			rockchip,pins =
++				<0 RK_PA4 RK_FUNC_GPIO &pcfg_output_low>;
++		};
++
++		soc_slppin_slp: soc_slppin_slp {
++			rockchip,pins =
++				<0 RK_PA4 1 &pcfg_pull_none>;
++		};
++
++		soc_slppin_rst: soc_slppin_rst {
++			rockchip,pins =
++				<0 RK_PA4 2 &pcfg_pull_none>;
++		};
++	};
++
++	uart2-m1 {
++		uart2m1_xfer: uart2m1-xfer {
++			rockchip,pins =
++				<2 RK_PB4 2 &pcfg_pull_up>,
++				<2 RK_PB6 2 &pcfg_pull_up_2ma>;
++		};
++	};
++	
++};
+-- 
+2.30.2
+


### PR DESCRIPTION
- file has not only been split but also reordered
- CSI and DSI objects are still under construction and partially commented out