### PR TITLE
OSM-243-fix-Audio

### DIFF
--- a/recipes-kernel/linux/linux-rockchip_5.10.bbappend
+++ b/recipes-kernel/linux/linux-rockchip_5.10.bbappend
@@ -28,6 +28,7 @@ SRC_URI += " \
 	file://0025-drivers-dsi-implement-workaround-for-rockchip-dsi-bug.patch \
 	file://0026-arm64-dts-rockchip-enable-drm.patch \
 	file://0027-arm64-dts-iesy-change-LT8912-reset-to-dummy.patch \
+	file://0028-arm64-dts-iesy-assign-clock-rate-for-audio-codec.patch \
 "
 
 python () {

--- a/recipes-kernel/linux/linux-rockchip_5.10/0028-arm64-dts-iesy-assign-clock-rate-for-audio-codec.patch
+++ b/recipes-kernel/linux/linux-rockchip_5.10/0028-arm64-dts-iesy-assign-clock-rate-for-audio-codec.patch
@@ -1,0 +1,27 @@
+From 1094651e65fbb86c914c2875a32f3682cb6571dd Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Fri, 1 Dec 2023 08:30:00 +0100
+Subject: [PATCH 28/28] arm64: dts: iesy: assign clock rate for audio codec
+
+Clock needs to be configured by kernel, to be independent from bootloader
+---
+ arch/arm64/boot/dts/iesy/iesy-rpx30-eva-mi-v2.dts | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/iesy/iesy-rpx30-eva-mi-v2.dts b/arch/arm64/boot/dts/iesy/iesy-rpx30-eva-mi-v2.dts
+index 5aa2042b05f4..90a3c61eca71 100644
+--- a/arch/arm64/boot/dts/iesy/iesy-rpx30-eva-mi-v2.dts
++++ b/arch/arm64/boot/dts/iesy/iesy-rpx30-eva-mi-v2.dts
+@@ -524,6 +524,9 @@ max9867: audio_codec@18 {
+ 		compatible = "maxim,max9867";
+ 		reg = <0x18>;
+ 		status = "okay";
++		assigned-clocks = <&cru SCLK_I2S1_OUT>;
++		assigned-clock-parents = <&cru SCLK_I2S1_OUT>;
++		assigned-clock-rates = <50000000>;
+ 	};
+ };
+ 
+-- 
+2.30.2
+


### PR DESCRIPTION
Clock needs to be configured in kernel to be in dependent from chosen bootloader