### PR TITLE
u-boot: add recipe for u-boot-mainline

### DIFF
--- a/recipes-bsp/u-boot/rockchip-atf.bb
+++ b/recipes-bsp/u-boot/rockchip-atf.bb
@@ -1,0 +1,39 @@
+# Copyright (C) 2023 iesy GmbH
+
+SUMMARY = "Arm Trusted Firmware for Rockchip platforms"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://docs/license.rst;md5=b2c740efedc159745b9b31f88ff03dde"
+
+SRCREV = "${AUTOREV}"
+SRC_URI = "git://github.com/ARM-software/arm-trusted-firmware.git;protocol=https;branch=master"
+
+S = "${WORKDIR}/git"
+
+ATF_PLAT ?= "px30"
+
+inherit deploy
+
+PROVIDES = "virtual/arm-trusted-firmware"
+
+EXTRA_OEMAKE = 'CROSS_COMPILE=${TARGET_PREFIX} CC="${TARGET_PREFIX}gcc ${TOOLCHAIN_OPTIONS}" V=1'
+EXTRA_OEMAKE += 'HOSTCC="${BUILD_CC} ${BUILD_CFLAGS} ${BUILD_LDFLAGS}"'
+EXTRA_OEMAKE += 'STAGING_INCDIR=${STAGING_INCDIR_NATIVE} STAGING_LIBDIR=${STAGING_LIBDIR_NATIVE}'
+
+do_compile() {
+    unset LDFLAGS
+    unset CFLAGS
+    unset CPPFLAGS
+    oe_runmake PLAT=${ATF_PLAT}
+}
+
+do_install[noexec] = "1"
+
+addtask deploy after do_compile
+do_deploy() {
+    install -Dm 0644 ${S}/build/px30/release/bl31/bl31.elf ${DEPLOYDIR}/bl31.elf
+}
+
+FILES:${PN} += " \
+    /boot \
+    /boot/bl31.elf \
+    "

--- a/recipes-bsp/u-boot/u-boot-mainline/0001-rockchip-px30-add-support-for-iesy-rpx30-eva-mi.patch
+++ b/recipes-bsp/u-boot/u-boot-mainline/0001-rockchip-px30-add-support-for-iesy-rpx30-eva-mi.patch
@@ -1,0 +1,1011 @@
+From e8fd7026b04bb86d5b4f1ae61b4f297dc2c6c34e Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Thu, 7 Dec 2023 14:11:54 +0100
+Subject: [PATCH] rockchip: px30: add support for iesy-rpx30-eva-mi
+
+---
+ arch/arm/dts/Makefile                         |   1 +
+ arch/arm/dts/iesy-rpx30-eva-mi-u-boot.dtsi    |  16 +
+ arch/arm/dts/iesy-rpx30-eva-mi.dts            | 263 +++++++++++++
+ arch/arm/dts/iesy-rpx30-osm-sf.dtsi           | 369 ++++++++++++++++++
+ arch/arm/mach-rockchip/px30/Kconfig           |   4 +
+ board/iesy/iesy_rpx30_eva_mi/Kconfig          |  21 +
+ board/iesy/iesy_rpx30_eva_mi/MAINTAINERS      |   6 +
+ board/iesy/iesy_rpx30_eva_mi/Makefile         |   7 +
+ .../iesy_rpx30_eva_mi/iesy_rpx30_eva_mi.c     |  37 ++
+ configs/iesy_rpx30_eva_mi_defconfig           | 120 ++++++
+ drivers/power/pmic/rk8xx.c                    |   2 +
+ include/configs/iesy_rpx30_eva_mi.h           |  37 ++
+ 12 files changed, 883 insertions(+)
+ create mode 100644 arch/arm/dts/iesy-rpx30-eva-mi-u-boot.dtsi
+ create mode 100644 arch/arm/dts/iesy-rpx30-eva-mi.dts
+ create mode 100644 arch/arm/dts/iesy-rpx30-osm-sf.dtsi
+ create mode 100644 board/iesy/iesy_rpx30_eva_mi/Kconfig
+ create mode 100644 board/iesy/iesy_rpx30_eva_mi/MAINTAINERS
+ create mode 100644 board/iesy/iesy_rpx30_eva_mi/Makefile
+ create mode 100644 board/iesy/iesy_rpx30_eva_mi/iesy_rpx30_eva_mi.c
+ create mode 100644 configs/iesy_rpx30_eva_mi_defconfig
+ create mode 100644 include/configs/iesy_rpx30_eva_mi.h
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 85fd5b1157..5fc2f69eba 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -79,6 +79,7 @@ dtb-$(CONFIG_MACH_S700) += \
+ 	s700-cubieboard7.dtb
+ 
+ dtb-$(CONFIG_ROCKCHIP_PX30) += \
++	iesy-rpx30-eva-mi.dtb \
+ 	px30-evb.dtb \
+ 	px30-firefly.dtb \
+ 	px30-engicam-px30-core-ctouch2.dtb \
+diff --git a/arch/arm/dts/iesy-rpx30-eva-mi-u-boot.dtsi b/arch/arm/dts/iesy-rpx30-eva-mi-u-boot.dtsi
+new file mode 100644
+index 0000000000..82028cc48f
+--- /dev/null
++++ b/arch/arm/dts/iesy-rpx30-eva-mi-u-boot.dtsi
+@@ -0,0 +1,16 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * (C) Copyright 2023 iesy GmbH
++ */
++
++#include "px30-u-boot.dtsi"
++
++/ {
++	chosen {
++		u-boot,spl-boot-order = "same-as-spl";
++	};
++};
++
++&rng {
++	status = "okay";
++};
+diff --git a/arch/arm/dts/iesy-rpx30-eva-mi.dts b/arch/arm/dts/iesy-rpx30-eva-mi.dts
+new file mode 100644
+index 0000000000..c0d779ebc0
+--- /dev/null
++++ b/arch/arm/dts/iesy-rpx30-eva-mi.dts
+@@ -0,0 +1,263 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2023 iesy GmbH
++ */
++
++/dts-v1/;
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++#include "iesy-rpx30-osm-sf.dtsi"
++
++/ {
++	model = "iesy RPX30 EVA-MI V2";
++	compatible = "rockchip,px30-evb", "rockchip,px30";
++
++	aliases {
++		mmc0 = &emmc;
++		mmc1 = &sdmmc;
++	};
++
++	chosen {
++		stdout-path = "serial2:115200n8";
++	};
++
++	adc-keys {
++		compatible = "adc-keys";
++		io-channels = <&saradc 2>;
++		io-channel-names = "buttons";
++		keyup-threshold-microvolt = <1800000>;
++		poll-interval = <100>;
++
++		esc-key {
++			label = "esc";
++			linux,code = <KEY_ESC>;
++			press-threshold-microvolt = <1310000>;
++		};
++
++		home-key {
++			label = "home";
++			linux,code = <KEY_HOME>;
++			press-threshold-microvolt = <624000>;
++		};
++
++		menu-key {
++			label = "menu";
++			linux,code = <KEY_MENU>;
++			press-threshold-microvolt = <987000>;
++		};
++
++		vol-down-key {
++			label = "volume down";
++			linux,code = <KEY_VOLUMEDOWN>;
++			press-threshold-microvolt = <300000>;
++		};
++
++		vol-up-key {
++			label = "volume up";
++			linux,code = <KEY_VOLUMEUP>;
++			press-threshold-microvolt = <17000>;
++		};
++	};
++
++	backlight: backlight {
++		compatible = "pwm-backlight";
++		pwms = <&pwm1 0 25000 0>;
++		power-supply = <&vcc3v3_lcd>;
++	};
++
++	emmc_pwrseq: emmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		pinctrl-0 = <&emmc_reset>;
++		pinctrl-names = "default";
++		reset-gpios = <&gpio1 RK_PB3 GPIO_ACTIVE_HIGH>;
++	};
++
++	vcc5v0_sys: vccsys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++};
++
++&csi_dphy {
++	status = "okay";
++};
++
++&display_subsystem {
++	status = "okay";
++};
++
++&dsi {
++	status = "okay";
++
++	ports {
++		mipi_out: port@1 {
++			reg = <1>;
++
++			mipi_out_panel: endpoint {
++				remote-endpoint = <&mipi_in_panel>;
++			};
++		};
++	};
++
++	panel@0 {
++		compatible = "xinpeng,xpp055c272";
++		reg = <0>;
++		backlight = <&backlight>;
++		iovcc-supply = <&vcc_1v8>;
++		vci-supply = <&vcc3v3_lcd>;
++
++		port {
++			mipi_in_panel: endpoint {
++				remote-endpoint = <&mipi_out_panel>;
++			};
++		};
++	};
++};
++
++&dsi_dphy {
++	status = "okay";
++};
++
++&gmac {
++	clock_in_out = "output";
++	phy-supply = <&vcc_rmii>;
++	snps,reset-gpio = <&gpio2 13 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	snps,reset-delays-us = <0 50000 50000>;
++	status = "okay";
++};
++
++&gpu {
++	mali-supply = <&vdd_log>;
++	status = "okay";
++};
++
++&i2c1 {
++	status = "okay";
++
++	sensor@d {
++		compatible = "asahi-kasei,ak8963";
++		reg = <0x0d>;
++		gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
++		vdd-supply = <&vcc3v0_pmu>;
++		mount-matrix = "1", /* x0 */
++			       "0", /* y0 */
++			       "0", /* z0 */
++			       "0", /* x1 */
++			       "1", /* y1 */
++			       "0", /* z1 */
++			       "0", /* x2 */
++			       "0", /* y2 */
++			       "1"; /* z2 */
++	};
++
++	touchscreen@14 {
++		compatible = "goodix,gt1151";
++		reg = <0x14>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PA5 IRQ_TYPE_LEVEL_LOW>;
++		irq-gpios = <&gpio0 RK_PA5 GPIO_ACTIVE_LOW>;
++		reset-gpios = <&gpio0 RK_PB4 GPIO_ACTIVE_HIGH>;
++		VDDIO-supply = <&vcc3v3_lcd>;
++	};
++
++	sensor@4c {
++		compatible = "fsl,mma7660";
++		reg = <0x4c>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PB7 IRQ_TYPE_LEVEL_LOW>;
++	};
++};
++
++&i2c2 {
++	status = "okay";
++
++	clock-frequency = <100000>;
++
++	/* These are relatively safe rise/fall times; TODO: measure */
++	i2c-scl-falling-time-ns = <50>;
++	i2c-scl-rising-time-ns = <300>;
++
++	ov5695: ov5695@36 {
++		compatible = "ovti,ov5695";
++		reg = <0x36>;
++		avdd-supply = <&vcc2v8_dvp>;
++		clocks = <&cru SCLK_CIF_OUT>;
++		clock-names = "xvclk";
++		dvdd-supply = <&vcc1v5_dvp>;
++		dovdd-supply = <&vcc1v8_dvp>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&cif_clkout_m0>;
++		reset-gpios = <&gpio2 14 GPIO_ACTIVE_LOW>;
++
++		port {
++			ucam_out: endpoint {
++				remote-endpoint = <&mipi_in_ucam>;
++				data-lanes = <1 2>;
++			};
++		};
++	};
++};
++
++&i2s1_2ch {
++	status = "okay";
++};
++
++&isp {
++	status = "okay";
++
++	ports {
++		port@0 {
++			mipi_in_ucam: endpoint@0 {
++				reg = <0>;
++				data-lanes = <1 2>;
++				remote-endpoint = <&ucam_out>;
++			};
++		};
++	};
++};
++
++&isp_mmu {
++	status = "okay";
++};
++
++&pinctrl {
++	headphone {
++		hp_det: hp-det {
++			rockchip,pins =
++				<2 RK_PB0 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	sdio-pwrseq {
++		wifi_enable_h: wifi-enable-h {
++			rockchip,pins =
++				<0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&pwm1 {
++	status = "okay";
++};
++
++&vopb {
++	status = "okay";
++};
++
++&vopb_mmu {
++	status = "okay";
++};
++
++&vopl {
++	status = "okay";
++};
++
++&vopl_mmu {
++	status = "okay";
++};
+diff --git a/arch/arm/dts/iesy-rpx30-osm-sf.dtsi b/arch/arm/dts/iesy-rpx30-osm-sf.dtsi
+new file mode 100644
+index 0000000000..93d0f5e57e
+--- /dev/null
++++ b/arch/arm/dts/iesy-rpx30-osm-sf.dtsi
+@@ -0,0 +1,369 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2023 iesy GmbH
++ */
++
++#include "px30.dtsi"
++
++/ {
++    aliases {
++        mmc0 = &emmc;
++        mmc1 = &sdcard;
++    };
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu1 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu2 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu3 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&emmc {
++	cap-mmc-highspeed;
++	mmc-hs200-1_8v;
++	non-removable;
++	mmc-pwrseq = <&emmc_pwrseq>;
++	vmmc-supply = <&vcc_3v0>;
++	vqmmc-supply = <&vccio_flash>;
++	status = "okay";
++};
++
++&i2c0 {
++	status = "okay";
++
++	rk809: pmic@20 {
++		compatible = "rockchip,rk809";
++		reg = <0x20>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_int>;
++		rockchip,system-power-controller;
++		wakeup-source;
++		#clock-cells = <0>;
++		clock-output-names = "xin32k";
++		pmic-reset-func = <1>;
++
++		vcc1-supply = <&vcc5v0_sys>;
++		vcc2-supply = <&vcc5v0_sys>;
++		vcc3-supply = <&vcc5v0_sys>;
++		vcc4-supply = <&vcc5v0_sys>;
++		vcc5-supply = <&vcc3v3_sys>;
++		vcc6-supply = <&vcc3v3_sys>;
++		vcc7-supply = <&vcc3v3_sys>;
++		vcc8-supply = <&vcc3v3_sys>;
++		vcc9-supply = <&vcc5v0_sys>;
++
++		regulators {
++			vdd_log: DCDC_REG1 {
++				regulator-name = "vdd_log";
++				regulator-min-microvolt = <950000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <950000>;
++				};
++			};
++
++			vdd_arm: DCDC_REG2 {
++				regulator-name = "vdd_arm";
++				regulator-min-microvolt = <950000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <950000>;
++				};
++			};
++
++			vcc_ddr: DCDC_REG3 {
++				regulator-name = "vcc_ddr";
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_3v0: vcc_rmii: DCDC_REG4 {
++				regulator-name = "vcc_3v0";
++				regulator-min-microvolt = <3000000>;
++				regulator-max-microvolt = <3000000>;
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3000000>;
++				};
++			};
++
++			vcc3v3_sys: DCDC_REG5 {
++				regulator-name = "vcc3v3_sys";
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vcc_1v0: LDO_REG1 {
++				regulator-name = "vcc_1v0";
++				regulator-min-microvolt = <1000000>;
++				regulator-max-microvolt = <1000000>;
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++
++			vcc_1v8: vccio_flash: vccio_sdio: LDO_REG2 {
++				regulator-name = "vcc_1v8";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_1v0: LDO_REG3 {
++				regulator-name = "vdd_1v0";
++				regulator-min-microvolt = <1000000>;
++				regulator-max-microvolt = <1000000>;
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++
++			vcc3v0_pmu: LDO_REG4 {
++				regulator-name = "vcc3v0_pmu";
++				regulator-min-microvolt = <3000000>;
++				regulator-max-microvolt = <3000000>;
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3000000>;
++				};
++			};
++
++			vccio_sd: LDO_REG5 {
++				regulator-name = "vccio_sd";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vcc_sd: LDO_REG6 {
++				regulator-name = "vcc_sd";
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vcc2v8_dvp: LDO_REG7 {
++				regulator-name = "vcc2v8_dvp";
++				regulator-min-microvolt = <2800000>;
++				regulator-max-microvolt = <2800000>;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <2800000>;
++				};
++			};
++
++			vcc1v8_dvp: LDO_REG8 {
++				regulator-name = "vcc1v8_dvp";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc1v5_dvp: LDO_REG9 {
++				regulator-name = "vcc1v5_dvp";
++				regulator-min-microvolt = <1500000>;
++				regulator-max-microvolt = <1500000>;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <1500000>;
++				};
++			};
++
++			vcc3v3_lcd: SWITCH_REG1 {
++				regulator-name = "vcc3v3_lcd";
++				regulator-boot-on;
++			};
++
++			vcc5v0_host: SWITCH_REG2 {
++				regulator-name = "vcc5v0_host";
++				regulator-always-on;
++				regulator-boot-on;
++			};
++		};
++	};
++};
++
++&io_domains {
++	status = "okay";
++
++	vccio1-supply = <&vccio_sdio>;
++	vccio2-supply = <&vccio_sd>;
++	vccio3-supply = <&vcc_3v0>;
++	vccio4-supply = <&vcc3v0_pmu>;
++	vccio5-supply = <&vcc_3v0>;
++	vccio6-supply = <&vccio_flash>;
++};
++
++&pinctrl {
++    emmc {
++		emmc_reset: emmc-reset {
++			rockchip,pins = <1 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pmic {
++		pmic_int: pmic_int {
++			rockchip,pins =
++				<0 RK_PA7 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		soc_slppin_gpio: soc_slppin_gpio {
++			rockchip,pins =
++				<0 RK_PA4 RK_FUNC_GPIO &pcfg_output_low>;
++		};
++
++		soc_slppin_slp: soc_slppin_slp {
++			rockchip,pins =
++				<0 RK_PA4 1 &pcfg_pull_none>;
++		};
++
++		soc_slppin_rst: soc_slppin_rst {
++			rockchip,pins =
++				<0 RK_PA4 2 &pcfg_pull_none>;
++		};
++	};
++};
++
++&pmu_io_domains {
++	status = "okay";
++
++	pmuio1-supply = <&vcc3v0_pmu>;
++	pmuio2-supply = <&vcc3v0_pmu>;
++};
++
++&saradc {
++	vref-supply = <&vcc_1v8>;
++	status = "okay";
++};
++
++&sdmmc {
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	card-detect-delay = <800>;
++	sd-uhs-sdr12;
++	sd-uhs-sdr25;
++	sd-uhs-sdr50;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc_sd>;
++	vqmmc-supply = <&vccio_sd>;
++	status = "okay";
++};
++
++&tsadc {
++	rockchip,hw-tshut-mode = <1>;
++	rockchip,hw-tshut-polarity = <1>;
++	status = "okay";
++};
++
++&u2phy {
++	status = "okay";
++
++	u2phy_host: host-port {
++		status = "okay";
++	};
++
++	u2phy_otg: otg-port {
++		status = "okay";
++	};
++};
++
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_xfer &uart1_cts>;
++	status = "okay";
++};
++
++&uart2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart2m1_xfer>;
++	status = "okay";
++};
++
++&uart5 {
++	status = "okay";
++};
++
++&usb20_otg {
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
+\ No newline at end of file
+diff --git a/arch/arm/mach-rockchip/px30/Kconfig b/arch/arm/mach-rockchip/px30/Kconfig
+index 41893920cb..a6bfe76091 100644
+--- a/arch/arm/mach-rockchip/px30/Kconfig
++++ b/arch/arm/mach-rockchip/px30/Kconfig
+@@ -59,6 +59,9 @@ config TARGET_RINGNECK_PX30
+ 	    * on-module Espressif ESP32 for Bluetooth + 2.4GHz WiFi
+ 	    * on-module NXP SE05x Secure Element
+ 
++config TARGET_IESY_RPX30_EVA_MI
++	bool "iesy RPX30 EVA MI"	
++
+ config ROCKCHIP_BOOT_MODE_REG
+ 	default 0xff010200
+ 
+@@ -94,6 +97,7 @@ config DEBUG_UART_CHANNEL
+ 
+ source "board/engicam/px30_core/Kconfig"
+ source "board/hardkernel/odroid_go2/Kconfig"
++source "board/iesy/iesy_rpx30_eva_mi/Kconfig"
+ source "board/rockchip/evb_px30/Kconfig"
+ source "board/theobroma-systems/ringneck_px30/Kconfig"
+ 
+diff --git a/board/iesy/iesy_rpx30_eva_mi/Kconfig b/board/iesy/iesy_rpx30_eva_mi/Kconfig
+new file mode 100644
+index 0000000000..5441f2bb37
+--- /dev/null
++++ b/board/iesy/iesy_rpx30_eva_mi/Kconfig
+@@ -0,0 +1,21 @@
++if TARGET_IESY_RPX30_EVA_MI
++
++config SYS_BOARD
++	default "iesy_rpx30_eva_mi"
++
++config SYS_VENDOR
++	default "iesy"
++
++config SYS_CONFIG_NAME
++	default "iesy_rpx30_eva_mi"
++
++config BOARD_SPECIFIC_OPTIONS # dummy
++	def_bool y
++	select RAM_ROCKCHIP_LPDDR3
++	select ROCKCHIP_USB2_PHY
++	select USB_DWC2
++	select DM_USB_GADGET
++	imply USB_FUNCTION_ROCKUSB
++	imply CMD_ROCKUSB
++
++endif
+diff --git a/board/iesy/iesy_rpx30_eva_mi/MAINTAINERS b/board/iesy/iesy_rpx30_eva_mi/MAINTAINERS
+new file mode 100644
+index 0000000000..fae86f8fc9
+--- /dev/null
++++ b/board/iesy/iesy_rpx30_eva_mi/MAINTAINERS
+@@ -0,0 +1,6 @@
++iesy RPX30 EVA MI
++M:      Dominik Poggel <kever.yang@rock-chips.com>
++S:      Maintained
++F:      board/iesy/iesy_rpx30_eva_mi
++F:      include/configs/iesy_rpx30_eva_mi.h
++F:      configs/iesy_rpx30_eva_mi_defconfig
+diff --git a/board/iesy/iesy_rpx30_eva_mi/Makefile b/board/iesy/iesy_rpx30_eva_mi/Makefile
+new file mode 100644
+index 0000000000..7938d85e13
+--- /dev/null
++++ b/board/iesy/iesy_rpx30_eva_mi/Makefile
+@@ -0,0 +1,7 @@
++#
++# (C) Copyright 2023 iesy GmbH
++#
++# SPDX-License-Identifier:     GPL-2.0+
++#
++
++obj-y	+= iesy_rpx30_eva_mi.o
+diff --git a/board/iesy/iesy_rpx30_eva_mi/iesy_rpx30_eva_mi.c b/board/iesy/iesy_rpx30_eva_mi/iesy_rpx30_eva_mi.c
+new file mode 100644
+index 0000000000..4fa58b0b5f
+--- /dev/null
++++ b/board/iesy/iesy_rpx30_eva_mi/iesy_rpx30_eva_mi.c
+@@ -0,0 +1,37 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * (C) Copyright 2023 iesy GmbH
++ */
++
++
++// #include <common.h>
++// #include <dm.h>
++// #include <log.h>
++// #include <mmc.h>
++// #include <spl.h>
++// #include <asm/global_data.h>
++// #include <asm/arch-rockchip/misc.h>
++
++// #ifdef CONFIG_MISC_INIT_R
++// int misc_init_r(void)
++// {
++// 	const u32 cpuid_offset = CFG_CPUID_OFFSET;
++// 	const u32 cpuid_length = 0x10;
++// 	u8 cpuid[cpuid_length];
++// 	int ret;
++
++// 	ret = rockchip_cpuid_from_efuse(cpuid_offset, cpuid_length, cpuid);
++// 	if (ret)
++// 		return ret;
++
++// 	ret = rockchip_cpuid_set(cpuid, cpuid_length);
++// 	if (ret)
++// 		return ret;
++
++// 	ret = rockchip_setup_macaddr();
++
++//     printf("spl_boot_device() = %d\n", spl_boot_device());
++
++// 	return ret;
++// }
++// #endif
+\ No newline at end of file
+diff --git a/configs/iesy_rpx30_eva_mi_defconfig b/configs/iesy_rpx30_eva_mi_defconfig
+new file mode 100644
+index 0000000000..61c57a78df
+--- /dev/null
++++ b/configs/iesy_rpx30_eva_mi_defconfig
+@@ -0,0 +1,120 @@
++CONFIG_ARM=y
++CONFIG_SKIP_LOWLEVEL_INIT=y
++CONFIG_COUNTER_FREQUENCY=24000000
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_TEXT_BASE=0x00200000
++CONFIG_SYS_MALLOC_F_LEN=0x2000
++CONFIG_SPL_LIBCOMMON_SUPPORT=y
++CONFIG_SPL_LIBGENERIC_SUPPORT=y
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y
++CONFIG_CUSTOM_SYS_INIT_SP_ADDR=0x400000
++CONFIG_DEFAULT_DEVICE_TREE="iesy-rpx30-eva-mi"
++CONFIG_SPL_TEXT_BASE=0x00000000
++CONFIG_DM_RESET=y
++CONFIG_ROCKCHIP_PX30=y
++CONFIG_TARGET_IESY_RPX30_EVA_MI=y
++CONFIG_TPL_LIBGENERIC_SUPPORT=y
++CONFIG_SPL_DRIVERS_MISC=y
++CONFIG_SPL_STACK_R_ADDR=0x600000
++CONFIG_SPL_STACK=0x400000
++CONFIG_TPL_SYS_MALLOC_F_LEN=0x600
++CONFIG_DEBUG_UART_BASE=0xFF160000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_DEBUG_UART_CHANNEL=1
++CONFIG_SYS_LOAD_ADDR=0x800800
++CONFIG_DEBUG_UART=y
++# CONFIG_ANDROID_BOOT_IMAGE is not set
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_DEFAULT_FDT_FILE="iesy-rpx30-eva-mi-v2.dtb"
++# CONFIG_CONSOLE_MUX is not set
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++CONFIG_MISC_INIT_R=y
++CONFIG_SPL_MAX_SIZE=0x20000
++CONFIG_SPL_PAD_TO=0x7f8000
++CONFIG_SPL_HAS_BSS_LINKER_SECTION=y
++CONFIG_SPL_BSS_START_ADDR=0x4000000
++CONFIG_SPL_BSS_MAX_SIZE=0x4000
++CONFIG_SPL_BOOTROM_SUPPORT=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++# CONFIG_SPL_SHARES_INIT_SP_ADDR is not set
++CONFIG_SPL_STACK_R=y
++CONFIG_SPL_ATF=y
++# CONFIG_TPL_FRAMEWORK is not set
++# CONFIG_TPL_BANNER_PRINT is not set
++# CONFIG_CMD_BOOTD is not set
++# CONFIG_CMD_ELF is not set
++# CONFIG_CMD_IMI is not set
++# CONFIG_CMD_XIMG is not set
++# CONFIG_CMD_LZMADEC is not set
++# CONFIG_CMD_UNZIP is not set
++CONFIG_CMD_GPT=y
++# CONFIG_CMD_LOADB is not set
++# CONFIG_CMD_LOADS is not set
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_USB_MASS_STORAGE=y
++# CONFIG_CMD_ITEST is not set
++# CONFIG_CMD_SETEXPR is not set
++# CONFIG_CMD_SLEEP is not set
++# CONFIG_SPL_DOS_PARTITION is not set
++# CONFIG_ISO_PARTITION is not set
++CONFIG_EFI_PARTITION_ENTRIES_NUMBERS=64
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_OF_LIVE=y
++CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_REGMAP=y
++CONFIG_SPL_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_SPL_SYSCON=y
++CONFIG_CLK=y
++CONFIG_SPL_CLK=y
++CONFIG_FASTBOOT_BUF_ADDR=0x800800
++CONFIG_FASTBOOT_BUF_SIZE=0x04000000
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MISC=y
++CONFIG_ROCKCHIP_OTP=y
++CONFIG_SUPPORT_EMMC_RPMB=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_PHY_REALTEK=y
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_PINCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_SPL_PMIC_RK8XX=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM=y
++CONFIG_SPL_RAM=y
++CONFIG_TPL_RAM=y
++CONFIG_ROCKCHIP_SDRAM_COMMON=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_ROCKCHIP=y
++# CONFIG_SPECIFY_CONSOLE_INDEX is not set
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYS_NS16550_MEM32=y
++CONFIG_SOUND=y
++CONFIG_SYSRESET=y
++CONFIG_DM_THERMAL=y
++CONFIG_USB=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_DWC2_OTG=y
++CONFIG_VIDEO=y
++CONFIG_DISPLAY=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_TPL_TINY_MEMSET=y
++CONFIG_LZO=y
++CONFIG_ERRNO_STR=y
++# CONFIG_EFI_LOADER is not set
+diff --git a/drivers/power/pmic/rk8xx.c b/drivers/power/pmic/rk8xx.c
+index 25ef621f8d..917f16ca77 100644
+--- a/drivers/power/pmic/rk8xx.c
++++ b/drivers/power/pmic/rk8xx.c
+@@ -88,6 +88,8 @@ static struct reg_data rk817_init_reg[] = {
+  * the under-voltage protection will shutdown the LDO3 and reset the PMIC
+  */
+ 	{ RK817_BUCK4_CMIN, 0x60, 0x60},
++	/* Do not restart PMU, only reset DCDC and LDO */
++	{ RK817_PMIC_SYS_CFG3, 0x40, 0xc0 },
+ };
+ 
+ static const struct pmic_child_info pmic_children_info[] = {
+diff --git a/include/configs/iesy_rpx30_eva_mi.h b/include/configs/iesy_rpx30_eva_mi.h
+new file mode 100644
+index 0000000000..4ae49f5712
+--- /dev/null
++++ b/include/configs/iesy_rpx30_eva_mi.h
+@@ -0,0 +1,37 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * (C) Copyright 2017 Rockchip Electronics Co., Ltd
++ */
++
++#ifndef __IESY_RPX30_EVA_MI_H
++#define __IESY_RPX30_EVA_MI_H
++
++#include "rockchip-common.h"
++
++#define CFG_IRAM_BASE		0xff0e0000
++
++#define GICD_BASE			0xff131000
++#define GICC_BASE			0xff132000
++
++#define CFG_SYS_SDRAM_BASE		0
++#define SDRAM_MAX_SIZE			0xff000000
++
++#define ENV_MEM_LAYOUT_SETTINGS \
++	"scriptaddr=0x00500000\0" \
++	"pxefile_addr_r=0x00600000\0" \
++	"fdt_addr_r=0x08300000\0" \
++	"kernel_addr_r=0x00280000\0" \
++	"ramdisk_addr_r=0x0a200000\0" \
++	"kernel_comp_addr_r=0x03e80000\0" \
++	"kernel_comp_size=0x2000000\0"
++
++#define CFG_EXTRA_ENV_SETTINGS \
++	ENV_MEM_LAYOUT_SETTINGS \
++	"fdtfile=" CONFIG_DEFAULT_FDT_FILE "\0" \
++	"partitions=" PARTS_DEFAULT \
++	"boot_targets=" BOOT_TARGETS "\0" \
++	"bootcmd=fatload mmc 1 ${kernel_addr_r} Image; " \
++		"fatload mmc 1 ${fdt_addr_r} ${fdtfile}; " \
++		"booti ${kernel_addr_r} - ${fdt_addr_r}\0"
++
++#endif
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/u-boot-mainline_2023.10.bb
+++ b/recipes-bsp/u-boot/u-boot-mainline_2023.10.bb
@@ -1,0 +1,32 @@
+# Copyright (C) 2023 iesy GmbH
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/u-boot-mainline:"
+
+require recipes-bsp/u-boot/u-boot-common.inc
+require recipes-bsp/u-boot/u-boot.inc
+
+PROVIDES = "virtual/bootloader"
+
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=2ca5f2c35c8cc335f0a19756634782f1"
+
+SRCREV = "4459ed60cb1e0562bc5b40405e2b4b9bbf766d57"
+# SRCREV = "${AUTOREV}"
+
+DEPENDS += "rockchip-atf bc-native dtc-native python3-pyelftools-native"
+
+SRC_URI += " \
+        file://0001-rockchip-px30-add-support-for-iesy-rpx30-eva-mi.patch \
+    "
+
+do_patch() {
+	cd ${S}
+	git am ${WORKDIR}/*.patch
+}
+
+do_compile:prepend () {
+    export BL31=${DEPLOY_DIR_IMAGE}/bl31.elf
+}
+
+do_deploy:append () {
+    install -Dm 0644 ${B}/u-boot-rockchip.bin ${DEPLOYDIR}/u-boot-rockchip.bin
+}

--- a/wic/rockchip-gptdisk.wks.in
+++ b/wic/rockchip-gptdisk.wks.in
@@ -1,0 +1,10 @@
+# Copyright (c) 2023, iesy GmbH
+# Released under the MIT license (see COPYING.MIT for the terms)
+#
+# long-description: Creates a GPT disk image for iesy Rockchip modules
+
+# 0~32K: gpt
+bootloader --ptable gpt
+part --source rawcopy --sourceparams="file=u-boot-rockchip.bin" --align 32 --no-table
+part --source bootimg-partition --fstype vfat --sourceparams="file=boot.img" --part-name boot
+part / --source rootfs --fstype ${RK_ROOTFS_TYPE} --part-name rootfs --uuid ${RK_ROOTDEV_UUID} --align 8192


### PR DESCRIPTION
to use with iesy-rpx30-eva-mi, add following to the machine file:
UBOOT_MACHINE = "iesy_rpx30_eva_mi_defconfig"
ATF_PLAT= "px30"
PREFERRED_PROVIDER_virtual/bootloader = "u-boot-mainline"
WKS_FILE = "rockchip-gptdisk.wks.in"
IMAGE_BOOT_FILES = "Image iesy-rpx30-eva-mi-v2.dtb"