### PR TITLE
RPX30 OSM SF: disable unused regulators

### DIFF
--- a/recipes-kernel/linux/linux-rockchip_5.10.bbappend
+++ b/recipes-kernel/linux/linux-rockchip_5.10.bbappend
@@ -29,6 +29,7 @@ SRC_URI += " \
 	file://0026-arm64-dts-rockchip-enable-drm.patch \
 	file://0027-arm64-dts-iesy-change-LT8912-reset-to-dummy.patch \
 	file://0028-arm64-dts-iesy-assign-clock-rate-for-audio-codec.patch \
+	file://0029-arm64-dts-iesy-iesy-rpx30-osm-sf-disable-unused-regu.patch \
 "
 
 python () {

--- a/recipes-kernel/linux/linux-rockchip_5.10/0029-arm64-dts-iesy-iesy-rpx30-osm-sf-disable-unused-regu.patch
+++ b/recipes-kernel/linux/linux-rockchip_5.10/0029-arm64-dts-iesy-iesy-rpx30-osm-sf-disable-unused-regu.patch
@@ -1,0 +1,44 @@
+From 2ea1cc9c7a759af4b5aca4556d40c6515e5e48ae Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Wed, 20 Dec 2023 08:32:33 +0100
+Subject: [PATCH 29/29] arm64: dts: iesy: iesy-rpx30-osm-sf: disable unused
+ regulators
+
+The regulators are unused. Comment out to prevent unnecessary debug logs
+---
+ arch/arm64/boot/dts/iesy/iesy-rpx30-osm-sf.dtsi | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/iesy/iesy-rpx30-osm-sf.dtsi b/arch/arm64/boot/dts/iesy/iesy-rpx30-osm-sf.dtsi
+index 1d0de6bbc834b..d9e4a2aa3744b 100644
+--- a/arch/arm64/boot/dts/iesy/iesy-rpx30-osm-sf.dtsi
++++ b/arch/arm64/boot/dts/iesy/iesy-rpx30-osm-sf.dtsi
+@@ -356,6 +356,7 @@ regulator-state-mem {
+ 			};
+ 
+             /* LDO9: unused */
++			/* 
+ 			vdd1v5_dvp: LDO_REG9 {
+ 				regulator-min-microvolt = <1500000>;
+ 				regulator-max-microvolt = <1500000>;
+@@ -365,11 +366,14 @@ regulator-state-mem {
+ 					regulator-off-in-suspend;
+ 					regulator-suspend-microvolt = <1500000>;
+ 				};
+-			};
+-
++			}; */
++			
++			
++			/* Switch 1: unused */
++			/*
+ 			vcc5v0_host: SWITCH_REG1 {
+ 				regulator-name = "vcc5v0_host";
+-			};
++			}; */
+ 
+ 			vcc3v3_lcd: SWITCH_REG2 {
+ 				regulator-name = "vcc3v3_lcd";
+-- 
+2.30.2
+


### PR DESCRIPTION
The regulators are unused. Comment out to prevent unnecessary debug logs.

vcc3v3_lcd is also not in use, but the panel node depends on it.