### PR TITLE
fix build failure caused by AUTOREV

### DIFF
--- a/recipes-bsp/u-boot/u-boot-mainline_2023.10.bb
+++ b/recipes-bsp/u-boot/u-boot-mainline_2023.10.bb
@@ -10,7 +10,7 @@ PROVIDES = "virtual/bootloader"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=2ca5f2c35c8cc335f0a19756634782f1"
 
 SRCREV = "4459ed60cb1e0562bc5b40405e2b4b9bbf766d57"
-SRCREV_rkbin = "${AUTOREV}"
+SRCREV_rkbin = "b4558da0860ca48bf1a571dd33ccba580b9abe23"
 
 PV = "2023.10"
 

--- a/recipes-bsp/u-boot/u-boot-mainline_2024.01.bb
+++ b/recipes-bsp/u-boot/u-boot-mainline_2024.01.bb
@@ -10,7 +10,7 @@ PROVIDES = "virtual/bootloader"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=2ca5f2c35c8cc335f0a19756634782f1"
 
 SRCREV = "866ca972d6c3cabeaf6dbac431e8e08bb30b3c8e"
-SRCREV_rkbin = "${AUTOREV}"
+SRCREV_rkbin = "b4558da0860ca48bf1a571dd33ccba580b9abe23"
 
 PV = "2024.01"
 


### PR DESCRIPTION
the use of AUTOREV seems to break the build, throwing "excpetion during build_dependencies for autorev". Setting the SRCREV to a fixed commit ID fixes this, the latest commit is used