### PR TITLE
RPX30 EVA-MI: update patch 0033

### DIFF
--- a/recipes-kernel/linux/linux-rockchip_5.10.bbappend
+++ b/recipes-kernel/linux/linux-rockchip_5.10.bbappend
@@ -32,7 +32,7 @@ SRC_URI += " \
 	file://0029-arm64-dts-iesy-iesy-rpx30-osm-sf-disable-unused-regu.patch \
 	file://0031-arm64-dts-iesy-set-HW-revision-for-rpx30-evalution-kits.patch \
 	file://0032-drivers-drm-bridge-fix-gpio-initialization.patch \
-  file://0033-arm64-dts-iesy-update-Makefile-with-renamed-dts.patch \
+  	file://0033-arm64-dts-iesy-update-Makefile-with-renamed-dts.patch \
 "
 
 python () {

--- a/recipes-kernel/linux/linux-rockchip_5.10/0033-arm64-dts-iesy-update-Makefile-with-renamed-dts.patch
+++ b/recipes-kernel/linux/linux-rockchip_5.10/0033-arm64-dts-iesy-update-Makefile-with-renamed-dts.patch
@@ -1,7 +1,7 @@
-From 5c831f6909fcf91af0fbc6243603c6eb789b2db3 Mon Sep 17 00:00:00 2001
+From 137d4d0cb1b37c12dab543c9c5ff23c44a7d7292 Mon Sep 17 00:00:00 2001
 From: Dominik Poggel <pog@iesy.com>
-Date: Thu, 8 Feb 2024 08:41:58 +0100
-Subject: [PATCH 33/33] arm64: dts: iesy: update Makefile with renamed dts
+Date: Thu, 8 Feb 2024 10:00:07 +0100
+Subject: [PATCH 33/36] arm64: dts: iesy: update Makefile with renamed dts
 
 The dts files for the px30 evaluation kits are now named according to their hardware revision. Update the Makefile to include this changes
 
@@ -11,15 +11,14 @@ Signed-off-by: Dominik Poggel <pog@iesy.com>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/iesy/Makefile b/arch/arm64/boot/dts/iesy/Makefile
-index 499a0f8d8795..a6ee5e24493c 100644
+index c0121a444f7c..ab99acaef40e 100644
 --- a/arch/arm64/boot/dts/iesy/Makefile
 +++ b/arch/arm64/boot/dts/iesy/Makefile
-@@ -1,3 +1,4 @@
+@@ -1,2 +1,3 @@
  # SPDX-License-Identifier: GPL-2.0
 -dtb-$(CONFIG_ARCH_ROCKCHIP) += iesy-rpx30-eva-mi.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += iesy-rpx30-eva-mi-v1.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += iesy-rpx30-eva-mi-v2.dtb
- dtb-$(CONFIG_ARCH_ROCKCHIP) += tb002-cm006b-r3.dtb
 -- 
 2.30.2
 


### PR DESCRIPTION
patch was generated from kernel that included patches from internal layer. Regenerated patch from clean meta-iesy-osm linux-rockchip kernel