### PR TITLE
Osm 153 setup script build environment

### DIFF
--- a/conf/bblayers.conf.am62
+++ b/conf/bblayers.conf.am62
@@ -1,0 +1,19 @@
+# POKY_BBLAYERS_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+POKY_BBLAYERS_CONF_VERSION = "1"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  ${TOPDIR}/../sources/meta-openembedded/meta-networking \
+	${TOPDIR}/../sources/meta-openembedded/meta-python \
+	${TOPDIR}/../sources/meta-openembedded/meta-oe \
+	${TOPDIR}/../sources/meta-ti/meta-ti-extras \
+	${TOPDIR}/../sources/meta-ti/meta-ti-bsp \
+	${TOPDIR}/../sources/meta-arm/meta-arm \
+	${TOPDIR}/../sources/meta-arm/meta-arm-toolchain \
+	${TOPDIR}/../sources/oe-core/meta \
+	${TOPDIR}/../sources/meta-iesy-osm \
+	${TOPDIR}/../sources/poky/meta-poky \
+"

--- a/conf/setup-env
+++ b/conf/setup-env
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+. sources/poky/oe-init-build-env
+
+if [ -n "$MACHINE" ]; then
+    sed -i 's/\(MACHINE ??= \)\(.*\)/\1"'$MACHINE'"/' conf/local.conf
+    echo "MACHINE set to $MACHINE"
+else
+    echo "MACHINE not set, using default from conf/local.conf"
+fi
+
+if [ -n "$DISTRO" ]; then
+    sed -i 's/\(DISTRO ?= \)\(.*\)/\1"'$DISTRO'"/' conf/local.conf
+    echo "DISTRO set to $DISTRO"
+else
+    echo "DISTRO not set, using default from conf/local.conf"
+fi


### PR DESCRIPTION
- conf: add a setup script for the build env
  this script calls the oe-init-build-env from poky, then sets MACHINE and DISTRO in the local.conf when given.
  e.g. MACHINE=iesy-am62xx-eva-mi DISTRO=iesy-wayland . setup-env build_iesy-wayland
- add a default bblayers.conf for the iesy-am62xx-eva-mi
  This bblayers contains the minimal needed layers for building an image for the iesy-am62xx-eva-mi.
