### PR TITLE
RPX30 EVA MI: add patch to quickly set DSI resolution

### DIFF
--- a/recipes-kernel/linux/linux-rockchip_5.10/0034-arm64-dts-iesy-set-DSI-resolution-to-1280x720-60Hz.patch
+++ b/recipes-kernel/linux/linux-rockchip_5.10/0034-arm64-dts-iesy-set-DSI-resolution-to-1280x720-60Hz.patch
@@ -1,0 +1,40 @@
+From 21da8753a2dd6c202c14ec10a6cc8360baf8838e Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Thu, 22 Feb 2024 09:25:38 +0100
+Subject: [PATCH 34/34] arm64: dts: iesy: set DSI resolution to 1280x720@60Hz
+
+Signed-off-by: Dominik Poggel <pog@iesy.com>
+---
+ arch/arm64/boot/dts/iesy/iesy-rpx30-eva-mi-v2.dts | 2 +-
+ drivers/gpu/drm/bridge/lt8912-i2c.c               | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/iesy/iesy-rpx30-eva-mi-v2.dts b/arch/arm64/boot/dts/iesy/iesy-rpx30-eva-mi-v2.dts
+index fd16316941a9..1dd2a7c636a8 100644
+--- a/arch/arm64/boot/dts/iesy/iesy-rpx30-eva-mi-v2.dts
++++ b/arch/arm64/boot/dts/iesy/iesy-rpx30-eva-mi-v2.dts
+@@ -293,7 +293,7 @@ panel@0 {
+ 		dsi,lanes = <2>;
+ 
+ 		display-timings {
+-			native-mode = <&timing2>;
++			native-mode = <&timing1>;
+ 
+ 			timing1: timing1 {
+ 				clock-frequency = <74250000>;
+diff --git a/drivers/gpu/drm/bridge/lt8912-i2c.c b/drivers/gpu/drm/bridge/lt8912-i2c.c
+index d35d0d0f27c8..e3117993955e 100644
+--- a/drivers/gpu/drm/bridge/lt8912-i2c.c
++++ b/drivers/gpu/drm/bridge/lt8912-i2c.c
+@@ -217,7 +217,7 @@ static void lt8912_audio_config(struct lt8912 *lt)
+ static void lt8912_mipi_config(struct lt8912 *lt)
+ {
+ 	//const struct drm_display_mode *mode = &lt->mode;
+-	struct video_timing *video = &video_1920x1080_30Hz;
++	struct video_timing *video = &video_1280x720_60Hz;
+ 
+ 	u32 hactive, hfp, hsync, hbp, vfp, vsync, vbp, htotal, vtotal;
+ 	unsigned int hsync_activehigh, vsync_activehigh, reg;
+-- 
+2.30.2
+


### PR DESCRIPTION
This patch sets the DSI resolution to 1280x720@60Hz. To include it, add it to the linux-rockchip*.bbappend