### PR TITLE
Osm 265 machine config auf mainline u boot umstellen

### DIFF
--- a/conf/machine/iesy-rpx30-eva-mi-v2.conf
+++ b/conf/machine/iesy-rpx30-eva-mi-v2.conf
@@ -3,6 +3,7 @@ require conf/machine/rockchip-px30-evb.conf
 MACHINE_NAME = "iesy RPX30 EVA-MI V2.xx (Eval Kit)"
 
 KERNEL_DEVICETREE = "iesy/iesy-rpx30-eva-mi-v2.dtb"
+UBOOT_MACHINE = "iesy_rpx30_eva_mi_defconfig"
 
 BBMASK += " \
 	.imx-gpu-viv.*.bbappend \
@@ -22,7 +23,13 @@ XSERVER = "xserver-xorg xf86-video-modesetting"
 # Prefer using Rockchip BSP kernel 4.19
 #PREFERRED_VERSION_linux-rockchip = "4.19%"
 #LINUXLIBCVERSION = "4.19-custom%"
+ATF_PLAT = "px30"
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-mainline"
 
 # Prefer using Rockchip BSP kernel 5.10
 PREFERRED_VERSION_linux-rockchip = "5.10%"
 LINUXLIBCVERSION = "5.10-custom%"
+
+WKS_FILE = "rockchip-gptdisk.wks.in"
+
+IMAGE_BOOT_FILES = "Image iesy-rpx30-eva-mi-v2.dtb"

--- a/recipes-bsp/u-boot/rockchip-atf.bb
+++ b/recipes-bsp/u-boot/rockchip-atf.bb
@@ -4,8 +4,8 @@ SUMMARY = "Arm Trusted Firmware for Rockchip platforms"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://docs/license.rst;md5=b2c740efedc159745b9b31f88ff03dde"
 
-SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/ARM-software/arm-trusted-firmware.git;protocol=https;branch=master"
+SRCREV = "a1be69e6c5db450f841f0edd9d734bf3cffb6621"
+SRC_URI = "git://github.com/ARM-software/arm-trusted-firmware.git;protocol=https;nobranch=1"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Set u-boot to mainline
Freeze ATF on specific commit (v2.10.2). Previously master-branch was used, but it is possibly unstable