### PR TITLE
AM62XX EVA MI: config ETH A phy, change LED behaviour

### DIFF
--- a/recipes-kernel/linux/linux-ti-staging_6.1.bbappend
+++ b/recipes-kernel/linux/linux-ti-staging_6.1.bbappend
@@ -5,6 +5,8 @@ SRC_URI += " \
     file://0002-arm64-dts-ti-iesy-am62x-config-memory.patch \
     file://0003-arm64-dts-ti-iesy-am62x-update-regulators-for-sd-car.patch \
     file://0004-arm64-dts-ti-iesy-am62x-add-PMIC-TPS65219.patch \
+    file://0005-arm64-dts-ti-iesy-am62x-config-eth-phy-sort-nodes.patch \
+    file://0006-driver-net-phy-config-eth-phy-behavior.patch \
 "
 
 do_patch(){

--- a/recipes-kernel/linux/linux-ti-staging_6.1/0005-arm64-dts-ti-iesy-am62x-config-eth-phy-sort-nodes.patch
+++ b/recipes-kernel/linux/linux-ti-staging_6.1/0005-arm64-dts-ti-iesy-am62x-config-eth-phy-sort-nodes.patch
@@ -1,0 +1,144 @@
+From 284339b77d477937251f20102a3e086b96f74952 Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Mon, 11 Mar 2024 12:25:20 +0100
+Subject: [PATCH 5/6] arm64: dts: ti: iesy-am62x: config eth phy, sort nodes
+
+Signed-off-by: Dominik Poggel <pog@iesy.com>
+---
+ .../boot/dts/ti/iesy-am62xx-eva-mi-v1.dts     | 37 ++++++++-----------
+ .../arm64/boot/dts/ti/iesy-am62xx-osm-lf.dtsi | 32 +++++++++-------
+ 2 files changed, 35 insertions(+), 34 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/ti/iesy-am62xx-eva-mi-v1.dts b/arch/arm64/boot/dts/ti/iesy-am62xx-eva-mi-v1.dts
+index 22ff4b0e6d9b..aa293d5f165c 100644
+--- a/arch/arm64/boot/dts/ti/iesy-am62xx-eva-mi-v1.dts
++++ b/arch/arm64/boot/dts/ti/iesy-am62xx-eva-mi-v1.dts
+@@ -7,6 +7,7 @@
+ 
+ /dts-v1/;
+ 
++#include <dt-bindings/net/mscc-phy-vsc8531.h>
+ #include "iesy-am62xx-osm-lf.dtsi"
+ 
+ / {
+@@ -116,23 +117,6 @@ vdd_core: regulator-8 {
+ };
+ 
+ &main_pmx0 {
+-	main_rgmii2_pins_default: main-rgmii2-pins-default {
+-		pinctrl-single,pins = <
+-			AM62X_IOPAD(0x184, PIN_INPUT, 0) /* (AE23) RGMII2_RD0 */
+-			AM62X_IOPAD(0x188, PIN_INPUT, 0) /* (AB20) RGMII2_RD1 */
+-			AM62X_IOPAD(0x18c, PIN_INPUT, 0) /* (AC21) RGMII2_RD2 */
+-			AM62X_IOPAD(0x190, PIN_INPUT, 0) /* (AE22) RGMII2_RD3 */
+-			AM62X_IOPAD(0x180, PIN_INPUT, 0) /* (AD23) RGMII2_RXC */
+-			AM62X_IOPAD(0x17c, PIN_INPUT, 0) /* (AD22) RGMII2_RX_CTL */
+-			AM62X_IOPAD(0x16c, PIN_OUTPUT, 0) /* (Y18) RGMII2_TD0 */
+-			AM62X_IOPAD(0x170, PIN_OUTPUT, 0) /* (AA18) RGMII2_TD1 */
+-			AM62X_IOPAD(0x174, PIN_OUTPUT, 0) /* (AD21) RGMII2_TD2 */
+-			AM62X_IOPAD(0x178, PIN_OUTPUT, 0) /* (AC20) RGMII2_TD3 */
+-			AM62X_IOPAD(0x168, PIN_OUTPUT, 0) /* (AE21) RGMII2_TXC */
+-			AM62X_IOPAD(0x164, PIN_OUTPUT, 0) /* (AA19) RGMII2_TX_CTL */
+-		>;
+-	};
+-
+ 	ospi0_pins_default: ospi0-pins-default {
+ 		pinctrl-single,pins = <
+ 			AM62X_IOPAD(0x000, PIN_OUTPUT, 0) /* (H24) OSPI0_CLK */
+@@ -243,22 +227,33 @@ wlcore: wlcore@2 {
+ };
+ 
+ &cpsw3g {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&main_rgmii1_pins_default
+-		     &main_rgmii2_pins_default>;
+-
+ 	cpts@3d000 {
+ 		/* MAP HW3_TS_PUSH to GENF1 */
+ 		ti,pps = <2 1>;
+ 	};
+ };
+ 
++&cpsw_port1 {
++	phy-mode = "rgmii-rxid";
++	phy-handle = <&cpsw3g_phy0>;
++};
++
+ &cpsw_port2 {
+ 	phy-mode = "rgmii-rxid";
+ 	phy-handle = <&cpsw3g_phy1>;
+ };
+ 
+ &cpsw3g_mdio {
++	cpsw3g_phy0: ethernet-phy@0 {
++		reg = <0>;
++		ti,rx-internal-delay = <DP83867_RGMIIDCTL_2_00_NS>;
++		ti,fifo-depth = <DP83867_PHYCR_FIFO_DEPTH_4_B_NIB>;
++		ti,min-output-impedance;
++		compatible = "ethernet-phy-id0007.0770";
++		vsc8531,led-0-mode = <VSC8531_LINK_1000_ACTIVITY>;
++		vsc8531,led-1-mode = <VSC8531_LINK_1000_ACTIVITY>;
++	};
++
+ 	cpsw3g_phy1: ethernet-phy@1 {
+ 		reg = <1>;
+ 		ti,rx-internal-delay = <DP83867_RGMIIDCTL_2_00_NS>;
+diff --git a/arch/arm64/boot/dts/ti/iesy-am62xx-osm-lf.dtsi b/arch/arm64/boot/dts/ti/iesy-am62xx-osm-lf.dtsi
+index 96626c616028..85a6824f2c1e 100644
+--- a/arch/arm64/boot/dts/ti/iesy-am62xx-osm-lf.dtsi
++++ b/arch/arm64/boot/dts/ti/iesy-am62xx-osm-lf.dtsi
+@@ -293,6 +293,23 @@ AM62X_IOPAD(0x12c, PIN_OUTPUT, 0) /* (AD19/V15) RGMII1_TX_CTL */
+ 		>;
+ 	};
+ 
++	main_rgmii2_pins_default: main-rgmii2-pins-default {
++		pinctrl-single,pins = <
++			AM62X_IOPAD(0x184, PIN_INPUT, 0) /* (AE23) RGMII2_RD0 */
++			AM62X_IOPAD(0x188, PIN_INPUT, 0) /* (AB20) RGMII2_RD1 */
++			AM62X_IOPAD(0x18c, PIN_INPUT, 0) /* (AC21) RGMII2_RD2 */
++			AM62X_IOPAD(0x190, PIN_INPUT, 0) /* (AE22) RGMII2_RD3 */
++			AM62X_IOPAD(0x180, PIN_INPUT, 0) /* (AD23) RGMII2_RXC */
++			AM62X_IOPAD(0x17c, PIN_INPUT, 0) /* (AD22) RGMII2_RX_CTL */
++			AM62X_IOPAD(0x16c, PIN_OUTPUT, 0) /* (Y18) RGMII2_TD0 */
++			AM62X_IOPAD(0x170, PIN_OUTPUT, 0) /* (AA18) RGMII2_TD1 */
++			AM62X_IOPAD(0x174, PIN_OUTPUT, 0) /* (AD21) RGMII2_TD2 */
++			AM62X_IOPAD(0x178, PIN_OUTPUT, 0) /* (AC20) RGMII2_TD3 */
++			AM62X_IOPAD(0x168, PIN_OUTPUT, 0) /* (AE21) RGMII2_TXC */
++			AM62X_IOPAD(0x164, PIN_OUTPUT, 0) /* (AA19) RGMII2_TX_CTL */
++		>;
++	};
++
+ 	ospi0_pins_default: ospi0-pins-default {
+ 		pinctrl-single,pins = <
+ 			AM62X_IOPAD(0x000, PIN_OUTPUT, 0) /* (H24) OSPI0_CLK */
+@@ -543,25 +560,14 @@ &sdhci1 {
+ 
+ &cpsw3g {
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&main_rgmii1_pins_default>;
+-};
+-
+-&cpsw_port1 {
+-	phy-mode = "rgmii-rxid";
+-	phy-handle = <&cpsw3g_phy0>;
++	pinctrl-0 = <&main_rgmii1_pins_default
++		     &main_rgmii2_pins_default>;
+ };
+ 
+ &cpsw3g_mdio {
+ 	status = "okay";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&main_mdio1_pins_default>;
+-
+-	cpsw3g_phy0: ethernet-phy@0 {
+-		reg = <0>;
+-		ti,rx-internal-delay = <DP83867_RGMIIDCTL_2_00_NS>;
+-		ti,fifo-depth = <DP83867_PHYCR_FIFO_DEPTH_4_B_NIB>;
+-		ti,min-output-impedance;
+-	};
+ };
+ 
+ &mailbox0_cluster0 {
+-- 
+2.30.2
+

--- a/recipes-kernel/linux/linux-ti-staging_6.1/0006-driver-net-phy-config-eth-phy-behavior.patch
+++ b/recipes-kernel/linux/linux-ti-staging_6.1/0006-driver-net-phy-config-eth-phy-behavior.patch
@@ -1,0 +1,49 @@
+From ef72054101c6c62959e6525df679704adcfeb302 Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Fri, 27 Oct 2023 13:24:08 +0200
+Subject: [PATCH 6/6] driver: net: phy: config eth-phy behavior
+
+Signed-off-by: Dominik Poggel <pog@iesy.com>
+---
+ drivers/net/phy/mscc/mscc.h      |  2 ++
+ drivers/net/phy/mscc/mscc_main.c | 11 +++++++++++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/drivers/net/phy/mscc/mscc.h b/drivers/net/phy/mscc/mscc.h
+index 0508ab182003..5f7523493d63 100644
+--- a/drivers/net/phy/mscc/mscc.h
++++ b/drivers/net/phy/mscc/mscc.h
+@@ -85,6 +85,8 @@ enum rgmii_clock_delay {
+ #define LED_MODE_SEL_MASK(x)		  (GENMASK(3, 0) << LED_MODE_SEL_POS(x))
+ #define LED_MODE_SEL(x, mode)		  (((mode) << LED_MODE_SEL_POS(x)) & LED_MODE_SEL_MASK(x))
+ 
++#define MSCC_PHY_LED_MODE_BEH		  30
++
+ #define MSCC_EXT_PAGE_CSR_CNTL_17	  17
+ #define MSCC_EXT_PAGE_CSR_CNTL_18	  18
+ 
+diff --git a/drivers/net/phy/mscc/mscc_main.c b/drivers/net/phy/mscc/mscc_main.c
+index 76589d219988..49f7f1d7cd18 100644
+--- a/drivers/net/phy/mscc/mscc_main.c
++++ b/drivers/net/phy/mscc/mscc_main.c
+@@ -181,6 +181,17 @@ static int vsc85xx_led_cntl_set(struct phy_device *phydev,
+ 	reg_val &= ~LED_MODE_SEL_MASK(led_num);
+ 	reg_val |= LED_MODE_SEL(led_num, (u16)mode);
+ 	rc = phy_write(phydev, MSCC_PHY_LED_MODE_SEL, reg_val);
++	if(rc)
++		goto led_cntl_set_cleanup;
++
++	if (led_num) {
++		reg_val = phy_read(phydev, MSCC_PHY_LED_MODE_BEH);
++		reg_val |= 0x0002;
++		rc = phy_write(phydev, MSCC_PHY_LED_MODE_BEH, reg_val);
++	}
++
++
++led_cntl_set_cleanup:
+ 	mutex_unlock(&phydev->lock);
+ 
+ 	return rc;
+-- 
+2.30.2
+


### PR DESCRIPTION
sort nodes between module and baseboard, config LED
add common patch for phy-led behaviour