### PR TITLE
i.MX93 EVA MI: u-boot-imx/linux-fslc-imx: add dts file, configure pmic

### DIFF
--- a/conf/machine/iesy-imx93-eva-mi.conf
+++ b/conf/machine/iesy-imx93-eva-mi.conf
@@ -4,12 +4,16 @@ MACHINE_NAME = "iesy i.MX93 EVA-MI (Eval Kit)"
 
 COMPATIBLE_MACHINE:iesy-imx93-eva-mi = "iesy-imx93-eva-mi"
 
+UBOOT_DTB_NAME = "iesy-imx93-eva-mi.dtb"
+UBOOT_CONFIG_BASENAME = "iesy_imx93_eva_mi"
+
+KERNEL_DEVICETREE = "\
+	iesy/iesy-imx93-eva-mi-v1.dtb \
+	"
+
 BBMASK += " \
 	.linux-rockchip.*.bbappend \
 	.u-boot-rockchip.*.bbappend \
 	.*linux-ti.*.bbappend \
 	.*u-boot-ti.*.bbappend \
 	"
-
-UBOOT_DTB_NAME = "iesy-imx93-eva-mi.dtb"
-UBOOT_CONFIG_BASENAME = "iesy_imx93_eva_mi"

--- a/recipes-bsp/u-boot/u-boot-imx/0004-arch-arm-dts-moved-pmic-from-i2c2-to-i2c1-and-config.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0004-arch-arm-dts-moved-pmic-from-i2c2-to-i2c1-and-config.patch
@@ -1,0 +1,170 @@
+From cd2252476a9d05fe4d7a5453d1573537be8f1393 Mon Sep 17 00:00:00 2001
+From: EliaFunk <eli@iesy.com>
+Date: Mon, 12 Aug 2024 10:57:14 +0200
+Subject: [PATCH 4/4] arch: arm: dts: moved pmic from i2c2 to i2c1 and
+ configured voltages
+
+Signed-off-by: EliaFunk <eli@iesy.com>
+---
+ arch/arm/dts/iesy-imx93-eva-mi-u-boot.dtsi |  4 +-
+ arch/arm/dts/iesy-imx93-eva-mi.dts         | 73 +++++++++++-----------
+ 2 files changed, 39 insertions(+), 38 deletions(-)
+
+diff --git a/arch/arm/dts/iesy-imx93-eva-mi-u-boot.dtsi b/arch/arm/dts/iesy-imx93-eva-mi-u-boot.dtsi
+index d85e6d69b41..3256a77cbd9 100644
+--- a/arch/arm/dts/iesy-imx93-eva-mi-u-boot.dtsi
++++ b/arch/arm/dts/iesy-imx93-eva-mi-u-boot.dtsi
+@@ -125,11 +125,11 @@
+ 	u-boot,dm-spl;
+ };
+ 
+-&{/soc@0/bus@44000000/i2c@44350000/pmic@25} {
++&{/soc@0/bus@44000000/i2c@44340000/pmic@25} {
+ 	u-boot,dm-spl;
+ };
+ 
+-&{/soc@0/bus@44000000/i2c@44350000/pmic@25/regulators} {
++&{/soc@0/bus@44000000/i2c@44340000/pmic@25/regulators} {
+ 	u-boot,dm-spl;
+ };
+ 
+diff --git a/arch/arm/dts/iesy-imx93-eva-mi.dts b/arch/arm/dts/iesy-imx93-eva-mi.dts
+index fb1b32c474a..ab1e869a510 100644
+--- a/arch/arm/dts/iesy-imx93-eva-mi.dts
++++ b/arch/arm/dts/iesy-imx93-eva-mi.dts
+@@ -179,30 +179,6 @@ dsi_host: dsi-host {
+ 	pinctrl-1 = <&pinctrl_lpi2c1>;
+ 	status = "okay";
+ 
+-	adv7535: hdmi@3d {
+-		compatible = "adi,adv7535";
+-		reg = <0x3d>;
+-		adi,addr-cec = <0x3c>;
+-		adi,dsi-lanes = <4>;
+-		status = "okay";
+-
+-		port {
+-			adv7535_to_dsi: endpoint {
+-				remote-endpoint = <&dsi_to_adv7535>;
+-			};
+-		};
+-	};
+-};
+-
+-&lpi2c2 {
+-	#address-cells = <1>;
+-	#size-cells = <0>;
+-	clock-frequency = <400000>;
+-	pinctrl-names = "default", "sleep";
+-	pinctrl-0 = <&pinctrl_lpi2c2>;
+-	pinctrl-1 = <&pinctrl_lpi2c2>;
+-	status = "okay";
+-
+ 	pmic@25 {
+ 		compatible = "nxp,pca9451a";
+ 		reg = <0x25>;
+@@ -212,8 +188,8 @@ dsi_host: dsi-host {
+ 		regulators {
+ 			buck1: BUCK1 {
+ 				regulator-name = "BUCK1";
+-				regulator-min-microvolt = <650000>;
+-				regulator-max-microvolt = <2237500>;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
+ 				regulator-boot-on;
+ 				regulator-always-on;
+ 				regulator-ramp-delay = <3125>;
+@@ -222,7 +198,7 @@ dsi_host: dsi-host {
+ 			buck2: BUCK2 {
+ 				regulator-name = "BUCK2";
+ 				regulator-min-microvolt = <600000>;
+-				regulator-max-microvolt = <2187500>;
++				regulator-max-microvolt = <600000>;
+ 				regulator-boot-on;
+ 				regulator-always-on;
+ 				regulator-ramp-delay = <3125>;
+@@ -230,32 +206,32 @@ dsi_host: dsi-host {
+ 
+ 			buck4: BUCK4{
+ 				regulator-name = "BUCK4";
+-				regulator-min-microvolt = <600000>;
+-				regulator-max-microvolt = <3400000>;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
+ 				regulator-boot-on;
+ 				regulator-always-on;
+ 			};
+ 
+ 			buck5: BUCK5{
+ 				regulator-name = "BUCK5";
+-				regulator-min-microvolt = <600000>;
+-				regulator-max-microvolt = <3400000>;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
+ 				regulator-boot-on;
+ 				regulator-always-on;
+ 			};
+ 
+ 			buck6: BUCK6 {
+ 				regulator-name = "BUCK6";
+-				regulator-min-microvolt = <600000>;
+-				regulator-max-microvolt = <3400000>;
++				regulator-min-microvolt = <1100000>;
++				regulator-max-microvolt = <1100000>;
+ 				regulator-boot-on;
+ 				regulator-always-on;
+ 			};
+ 
+ 			ldo1: LDO1 {
+ 				regulator-name = "LDO1";
+-				regulator-min-microvolt = <1600000>;
+-				regulator-max-microvolt = <3300000>;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
+ 				regulator-boot-on;
+ 				regulator-always-on;
+ 			};
+@@ -263,7 +239,7 @@ dsi_host: dsi-host {
+ 			ldo4: LDO4 {
+ 				regulator-name = "LDO4";
+ 				regulator-min-microvolt = <800000>;
+-				regulator-max-microvolt = <3300000>;
++				regulator-max-microvolt = <800000>;
+ 				regulator-boot-on;
+ 				regulator-always-on;
+ 			};
+@@ -278,6 +254,31 @@ dsi_host: dsi-host {
+ 		};
+ 	};
+ 
++
++	adv7535: hdmi@3d {
++		compatible = "adi,adv7535";
++		reg = <0x3d>;
++		adi,addr-cec = <0x3c>;
++		adi,dsi-lanes = <4>;
++		status = "okay";
++
++		port {
++			adv7535_to_dsi: endpoint {
++				remote-endpoint = <&dsi_to_adv7535>;
++			};
++		};
++	};
++};
++
++&lpi2c2 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	clock-frequency = <400000>;
++	pinctrl-names = "default", "sleep";
++	pinctrl-0 = <&pinctrl_lpi2c2>;
++	pinctrl-1 = <&pinctrl_lpi2c2>;
++	status = "okay";
++
+ 	pcal6524: gpio@22 {
+ 		compatible = "nxp,pcal6524";
+ 		pinctrl-names = "default";
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -4,6 +4,7 @@ SRC_URI += " \
     file://0001-arch-arm-Add-support-for-iesy-imx8mm-eva-mi.patch \
     file://0002-arch-arm-Add-support-for-iesy-imx93-eva-mi.patch \
     file://0003-Include-configs-modify-boot-command.patch \
+    file://0004-arch-arm-dts-moved-pmic-from-i2c2-to-i2c1-and-config.patch \
 "
 
 do_patch(){

--- a/recipes-kernel/linux/linux-fslc-imx/0005-arm64-boot-dts-iesy-add-support-for-iesy-imx93-eva-m.patch
+++ b/recipes-kernel/linux/linux-fslc-imx/0005-arm64-boot-dts-iesy-add-support-for-iesy-imx93-eva-m.patch
@@ -1,0 +1,1250 @@
+From 9d6412a127a957e42e48868ee980a23702c38a87 Mon Sep 17 00:00:00 2001
+From: EliaFunk <eli@iesy.com>
+Date: Mon, 12 Aug 2024 14:51:39 +0200
+Subject: [PATCH] arm64: boot: dts: iesy: add support for iesy-imx93-eva-mi
+
+Add devicetree for iesy-imx93-eva-mi and include devictree into makefile
+---
+ arch/arm64/boot/dts/iesy/Makefile             |    1 +
+ .../boot/dts/iesy/iesy-imx93-eva-mi-v1.dts    | 1220 +++++++++++++++++
+ 2 files changed, 1221 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/iesy/iesy-imx93-eva-mi-v1.dts
+
+diff --git a/arch/arm64/boot/dts/iesy/Makefile b/arch/arm64/boot/dts/iesy/Makefile
+index 3cd5a23e9b9e..bb12d1144247 100644
+--- a/arch/arm64/boot/dts/iesy/Makefile
++++ b/arch/arm64/boot/dts/iesy/Makefile
+@@ -1,2 +1,3 @@
+ dtb-$(CONFIG_ARCH_MXC) += iesy-imx8mm-eva-mi-v1.dtb
++dtb-$(CONFIG_ARCH_MXC) += iesy-imx93-eva-mi-v1.dtb
+ dtb-$(CONFIG_ARCH_MXC) += tb002-cm0007c-r1.dtb
+\ No newline at end of file
+diff --git a/arch/arm64/boot/dts/iesy/iesy-imx93-eva-mi-v1.dts b/arch/arm64/boot/dts/iesy/iesy-imx93-eva-mi-v1.dts
+new file mode 100644
+index 000000000000..8963799aafbf
+--- /dev/null
++++ b/arch/arm64/boot/dts/iesy/iesy-imx93-eva-mi-v1.dts
+@@ -0,0 +1,1220 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright 2022 NXP
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/usb/pd.h>
++#include "../freescale/imx93.dtsi"
++
++&ele_fw2 {
++	memory-region = <&ele_reserved>;
++};
++
++/ {
++	model = "iesy i.MX93 EVA-MI V1.xx (Eval Kit)";
++	compatible = "fsl,imx93-11x11-evk", "fsl,imx93";
++
++	chosen {
++		stdout-path = &lpuart1;
++	};
++
++	reserved-memory {
++		#address-cells = <2>;
++		#size-cells = <2>;
++		ranges;
++
++		linux,cma {
++			compatible = "shared-dma-pool";
++			reusable;
++			alloc-ranges = <0 0x80000000 0 0x40000000>;
++			size = <0 0x10000000>;
++			linux,cma-default;
++		};
++
++		/*ethosu_mem: ethosu_region@C0000000 {
++			compatible = "shared-dma-pool";
++			reusable;
++			reg = <0x0 0xC0000000 0x0 0x10000000>;
++		};*/
++
++		vdev0vring0: vdev0vring0@a4000000 {
++			reg = <0 0xa4000000 0 0x8000>;
++			no-map;
++		};
++
++		vdev0vring1: vdev0vring1@a4008000 {
++			reg = <0 0xa4008000 0 0x8000>;
++			no-map;
++		};
++
++		vdev1vring0: vdev1vring0@a4010000 {
++			reg = <0 0xa4010000 0 0x8000>;
++			no-map;
++		};
++
++		vdev1vring1: vdev1vring1@a4018000 {
++			reg = <0 0xa4018000 0 0x8000>;
++			no-map;
++		};
++
++		rsc_table: rsc-table@2021e000 {
++			reg = <0 0x2021e000 0 0x1000>;
++			no-map;
++		};
++
++		vdevbuffer: vdevbuffer@a4020000 {
++			compatible = "shared-dma-pool";
++			reg = <0 0xa4020000 0 0x100000>;
++			no-map;
++		};
++
++		ele_reserved: ele-reserved@a4120000 {
++			compatible = "shared-dma-pool";
++			reg = <0 0xa4120000 0 0x100000>;
++			no-map;
++		};
++	};
++
++	/*ethosu {
++		compatible = "arm,ethosu";
++		fsl,cm33-proc = <&cm33>;
++		memory-region = <&ethosu_mem>;
++		power-domains = <&mlmix>;
++	};*/
++
++	reg_can2_stby: regulator-can2-stby {
++		compatible = "regulator-fixed";
++		regulator-name = "can2-stby";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&adp5585gpio 5 GPIO_ACTIVE_LOW>;
++		enable-active-low;
++	};
++
++	reg_vref_1v8: regulator-adc-vref {
++		compatible = "regulator-fixed";
++		regulator-name = "vref_1v8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++	};
++
++	reg_usdhc2_vmmc: regulator-usdhc2 {
++		compatible = "regulator-fixed";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_reg_usdhc2_vmmc>;
++		regulator-name = "VSD_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&gpio3 7 GPIO_ACTIVE_HIGH>;
++		off-on-delay-us = <12000>;
++		enable-active-high;
++	};
++
++	reg_vdd_12v: regulator-vdd-12v {
++		compatible = "regulator-fixed";
++		regulator-name = "reg_vdd_12v";
++		regulator-min-microvolt = <12000000>;
++		regulator-max-microvolt = <12000000>;
++		gpio = <&pcal6524 14 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	reg_usdhc3_vmmc: regulator-usdhc3 {
++		compatible = "regulator-fixed";
++		regulator-name = "WLAN_EN";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&pcal6524 20 GPIO_ACTIVE_HIGH>;
++		/*
++		 * IW612 wifi chip needs more delay than other wifi chips to complete
++		 * the host interface initialization after power up, otherwise the
++		 * internal state of IW612 may be unstable, resulting in the failure of
++		 * the SDIO3.0 switch voltage.
++		 */
++		startup-delay-us = <20000>;
++		enable-active-high;
++	};
++
++	usdhc3_pwrseq: usdhc3_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&pcal6524 12 GPIO_ACTIVE_LOW>;
++	};
++
++	reg_audio_pwr: regulator-audio-pwr {
++		compatible = "regulator-fixed";
++		regulator-name = "audio-pwr";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&adp5585gpio 1 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		regulator-always-on;
++	};
++
++	reg_dvdd_sel: regulator-dvdd_sel {
++		compatible = "regulator-fixed";
++		regulator-name = "DVDD_SEL";
++		gpio = <&adp5585gpio_isp 0 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		startup-delay-us = <2000>;
++	};
++
++	reg_dvdd_1v2: regulator-dvdd {
++		compatible = "regulator-fixed";
++		regulator-name = "DVDD_1V2";
++		gpio = <&adp5585gpio_isp 6 GPIO_ACTIVE_HIGH>;
++		regulator-min-microvolt = <1200000>;
++		regulator-max-microvolt = <1200000>;
++		enable-active-high;
++		vin-supply = <&reg_dvdd_sel>;
++	};
++
++	reg_vdd_3v3: regulator-vdd {
++		compatible = "regulator-fixed";
++		regulator-name = "VDD_3V3";
++		gpio = <&adp5585gpio_isp 5 GPIO_ACTIVE_HIGH>;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <4000>;
++		enable-active-high;
++	};
++
++	reg_vddio_1v8: regulator-vddo {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDIO_1V8";
++		gpio = <&adp5585gpio_isp 9 GPIO_ACTIVE_HIGH>;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		startup-delay-us = <4000>;
++		enable-active-high;
++		vin-supply = <&reg_vdd_3v3>;
++	};
++
++	reg_vaa_sel: regulator-vaa_sel {
++		compatible = "regulator-fixed";
++		regulator-name = "VAA_SEL";
++		gpio = <&adp5585gpio_isp 1 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	reg_avdd_2v8: regulator-avdd {
++		compatible = "regulator-fixed";
++		regulator-name = "AVDD_2V8";
++		gpio = <&adp5585gpio_isp 7 GPIO_ACTIVE_HIGH>;
++		regulator-min-microvolt = <2800000>;
++		regulator-max-microvolt = <2800000>;
++		enable-active-high;
++		vin-supply = <&reg_vaa_sel>;
++	};
++
++	sound-wm8962 {
++		compatible = "fsl,imx-audio-wm8962";
++		model = "wm8962-audio";
++		audio-cpu = <&sai3>;
++		audio-codec = <&codec>;
++		hp-det-gpio = <&pcal6524 4 GPIO_ACTIVE_HIGH>;
++		audio-routing =
++			"Headphone Jack", "HPOUTL",
++			"Headphone Jack", "HPOUTR",
++			"Ext Spk", "SPKOUTL",
++			"Ext Spk", "SPKOUTR",
++			"AMIC", "MICBIAS",
++			"IN3R", "AMIC",
++			"IN1R", "AMIC";
++	};
++
++	sound-micfil {
++		compatible = "fsl,imx-audio-card";
++		model = "micfil-audio";
++		pri-dai-link {
++			link-name = "micfil hifi";
++			format = "i2s";
++			cpu {
++				sound-dai = <&micfil>;
++			};
++		};
++	};
++
++	bt_sco_codec: bt_sco_codec {
++		#sound-dai-cells = <1>;
++		compatible = "linux,bt-sco";
++	};
++
++	sound-bt-sco {
++		compatible = "simple-audio-card";
++		simple-audio-card,name = "bt-sco-audio";
++		simple-audio-card,format = "dsp_a";
++		simple-audio-card,bitclock-inversion;
++		simple-audio-card,frame-master = <&btcpu>;
++		simple-audio-card,bitclock-master = <&btcpu>;
++
++		btcpu: simple-audio-card,cpu {
++			sound-dai = <&sai1>;
++			dai-tdm-slot-num = <2>;
++			dai-tdm-slot-width = <16>;
++		};
++
++		simple-audio-card,codec {
++			sound-dai = <&bt_sco_codec 1>;
++		};
++	};
++
++	sound-xcvr {
++		compatible = "fsl,imx-audio-card";
++		model = "imx-audio-xcvr";
++		pri-dai-link {
++			link-name = "XCVR PCM";
++			cpu {
++				sound-dai = <&xcvr>;
++			};
++		};
++	};
++};
++
++&sai1 {
++	#sound-dai-cells = <0>;
++	pinctrl-names = "default", "sleep";
++	pinctrl-0 = <&pinctrl_sai1>;
++	pinctrl-1 = <&pinctrl_sai1_sleep>;
++	assigned-clocks = <&clk IMX93_CLK_SAI1>;
++	assigned-clock-parents = <&clk IMX93_CLK_AUDIO_PLL>;
++	assigned-clock-rates = <12288000>;
++	fsl,sai-mclk-direction-output;
++	status = "okay";
++};
++
++&sai3 {
++	pinctrl-names = "default", "sleep";
++	pinctrl-0 = <&pinctrl_sai3>;
++	pinctrl-1 = <&pinctrl_sai3_sleep>;
++	assigned-clocks = <&clk IMX93_CLK_SAI3>;
++	assigned-clock-parents = <&clk IMX93_CLK_AUDIO_PLL>;
++	assigned-clock-rates = <12288000>;
++	fsl,sai-mclk-direction-output;
++	status = "okay";
++};
++
++&micfil {
++	#sound-dai-cells = <0>;
++	pinctrl-names = "default", "sleep";
++	pinctrl-0 = <&pinctrl_pdm>;
++	pinctrl-1 = <&pinctrl_pdm_sleep>;
++	assigned-clocks = <&clk IMX93_CLK_PDM>;
++	assigned-clock-parents = <&clk IMX93_CLK_AUDIO_PLL>;
++	assigned-clock-rates = <49152000>;
++	status = "okay";
++};
++
++&xcvr {
++	#sound-dai-cells = <0>;
++	pinctrl-names = "default", "sleep";
++	pinctrl-0 = <&pinctrl_spdif>;
++	pinctrl-1 = <&pinctrl_spdif_sleep>;
++	clocks = <&clk IMX93_CLK_BUS_WAKEUP>,
++		<&clk IMX93_CLK_SPDIF_GATE>,
++		<&clk IMX93_CLK_DUMMY>,
++		<&clk IMX93_CLK_AUD_XCVR_GATE>,
++		<&clk IMX93_CLK_AUDIO_PLL>;
++	clock-names = "ipg", "phy", "spba", "pll_ipg", "pll8k";
++	assigned-clocks = <&clk IMX93_CLK_SPDIF>,
++			 <&clk IMX93_CLK_AUDIO_XCVR>;
++	assigned-clock-parents = <&clk IMX93_CLK_AUDIO_PLL>,
++			 <&clk IMX93_CLK_SYS_PLL_PFD1_DIV2>;
++	assigned-clock-rates = <12288000>, <200000000>;
++	status = "okay";
++};
++	
++&adc1 {
++	vref-supply = <&reg_vref_1v8>;
++	status = "okay";
++};
++
++&cm33 {
++	mbox-names = "tx", "rx", "rxdb";
++	mboxes = <&mu1 0 1>,
++		 <&mu1 1 1>,
++		 <&mu1 3 1>;
++	memory-region = <&vdevbuffer>, <&vdev0vring0>, <&vdev0vring1>,
++			<&vdev1vring0>, <&vdev1vring1>, <&rsc_table>;
++	fsl,startup-delay-ms = <500>;
++	status = "okay";
++};
++
++&dphy {
++	status = "okay";
++};
++
++&dsi {
++	status = "okay";
++
++	ports {
++		port@1 {
++			reg = <1>;
++
++			dsi_to_adv7535: endpoint {
++				remote-endpoint = <&adv7535_to_dsi>;
++			};
++		};
++	};
++};
++
++&flexcan2 {
++	pinctrl-names = "default", "sleep";
++	pinctrl-0 = <&pinctrl_flexcan2>;
++	pinctrl-1 = <&pinctrl_flexcan2_sleep>;
++	xceiver-supply = <&reg_can2_stby>;
++	status = "okay";
++};
++
++&mu1 {
++	status = "okay";
++};
++
++&mu2 {
++	status = "okay";
++};
++
++&eqos {
++	pinctrl-names = "default", "sleep";
++	pinctrl-0 = <&pinctrl_eqos>;
++	pinctrl-1 = <&pinctrl_eqos_sleep>;
++	phy-mode = "rgmii-id";
++	phy-handle = <&ethphy1>;
++	status = "okay";
++
++	mdio {
++		compatible = "snps,dwmac-mdio";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		clock-frequency = <5000000>;
++
++		ethphy1: ethernet-phy@1 {
++			reg = <1>;
++			eee-broken-1000t;
++		};
++	};
++};
++
++&fec {
++	pinctrl-names = "default", "sleep";
++	pinctrl-0 = <&pinctrl_fec>;
++	pinctrl-1 = <&pinctrl_fec_sleep>;
++	phy-mode = "rgmii-id";
++	phy-handle = <&ethphy2>;
++	fsl,magic-packet;
++	status = "okay";
++
++	mdio {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		clock-frequency = <5000000>;
++
++		ethphy2: ethernet-phy@2 {
++			reg = <2>;
++			eee-broken-1000t;
++		};
++	};
++};
++
++&lcdif {
++	status = "okay";
++	assigned-clock-rates = <445333333>, <148444444>, <400000000>, <133333333>;
++};
++
++&lpm {
++	soc-supply = <&buck1>;
++	status = "okay";
++};
++
++/*
++ * When add, delete or change any target device setting in &lpi2c1,
++ * please synchronize the changes to the &i3c1 bus in imx93-11x11-evk-i3c.dts.
++ */
++&lpi2c1 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	clock-frequency = <400000>;
++	pinctrl-names = "default", "sleep";
++	pinctrl-0 = <&pinctrl_lpi2c1>;
++	pinctrl-1 = <&pinctrl_lpi2c1>;
++	status = "okay";
++
++	codec: wm8962@1a {
++		compatible = "wlf,wm8962";
++		reg = <0x1a>;
++		clocks = <&clk IMX93_CLK_SAI3_GATE>;
++		DCVDD-supply = <&reg_audio_pwr>;
++		DBVDD-supply = <&reg_audio_pwr>;
++		AVDD-supply = <&reg_audio_pwr>;
++		CPVDD-supply = <&reg_audio_pwr>;
++		MICVDD-supply = <&reg_audio_pwr>;
++		PLLVDD-supply = <&reg_audio_pwr>;
++		SPKVDD1-supply = <&reg_audio_pwr>;
++		SPKVDD2-supply = <&reg_audio_pwr>;
++		gpio-cfg = <
++			0x0000 /* 0:Default */
++			0x0000 /* 1:Default */
++			0x0000 /* 2:FN_DMICCLK */
++			0x0000 /* 3:Default */
++			0x0000 /* 4:FN_DMICCDAT */
++			0x0000 /* 5:Default */
++		>;
++	};
++
++	pmic@25 {
++		compatible = "nxp,pca9451a";
++		reg = <0x25>;
++		interrupt-parent = <&pcal6524>;
++		interrupts = <11 IRQ_TYPE_EDGE_FALLING>;
++
++		regulators {
++			buck1: BUCK1 {
++				regulator-name = "BUCK1";
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++				regulator-boot-on;
++				regulator-always-on;
++				regulator-ramp-delay = <3125>;
++			};
++
++			buck2: BUCK2 {
++				regulator-name = "BUCK2";
++				regulator-min-microvolt = <600000>;
++				regulator-max-microvolt = <600000>;
++				regulator-boot-on;
++				regulator-always-on;
++				regulator-ramp-delay = <3125>;
++			};
++
++			buck4: BUCK4{
++				regulator-name = "BUCK4";
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++
++			buck5: BUCK5{
++				regulator-name = "BUCK5";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++
++			buck6: BUCK6 {
++				regulator-name = "BUCK6";
++				regulator-min-microvolt = <1100000>;
++				regulator-max-microvolt = <1100000>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++
++			ldo1: LDO1 {
++				regulator-name = "LDO1";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++
++			ldo4: LDO4 {
++				regulator-name = "LDO4";
++				regulator-min-microvolt = <800000>;
++				regulator-max-microvolt = <800000>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++
++			ldo5: LDO5 {
++				regulator-name = "LDO5";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++		};
++	};
++
++	adv7535: hdmi@3d {
++		compatible = "adi,adv7535";
++		reg = <0x3d>;
++		adi,addr-cec = <0x3b>;
++		adi,dsi-lanes = <4>;
++		status = "okay";
++
++		port {
++			adv7535_to_dsi: endpoint {
++				remote-endpoint = <&dsi_to_adv7535>;
++			};
++		};
++	};
++
++	lsm6dsm@6a {
++		compatible = "st,lsm6dso";
++		reg = <0x6a>;
++	};
++};
++
++&lpi2c2 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	clock-frequency = <400000>;
++	pinctrl-names = "default", "sleep";
++	pinctrl-0 = <&pinctrl_lpi2c2>;
++	pinctrl-1 = <&pinctrl_lpi2c2>;
++	status = "okay";
++
++	pcal6524: gpio@22 {
++		compatible = "nxp,pcal6524";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_pcal6524>;
++		reg = <0x22>;
++		gpio-controller;
++		#gpio-cells = <2>;
++		interrupt-controller;
++		#interrupt-cells = <2>;
++		interrupt-parent = <&gpio3>;
++		interrupts = <27 IRQ_TYPE_LEVEL_LOW>;
++	};
++
++	adp5585: mfd@34 {
++		compatible = "adi,adp5585";
++		reg = <0x34>;
++
++		adp5585gpio: gpio-adp5585 {
++			compatible = "adp5585-gpio";
++			gpio-controller;
++			#gpio-cells = <2>;
++		};
++
++		adp5585pwm: pwm-adp5585 {
++			compatible = "adp5585-pwm";
++			#pwm-cells = <3>;
++		};
++	};
++};
++
++&lpi2c3 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	clock-frequency = <400000>;
++	pinctrl-names = "default", "sleep";
++	pinctrl-0 = <&pinctrl_lpi2c3>;
++	pinctrl-1 = <&pinctrl_lpi2c3>;
++	status = "okay";
++
++	pcf2131: rtc@53 {
++			compatible = "nxp,pcf2131";
++			reg = <0x53>;
++			interrupt-parent = <&pcal6524>;
++			interrupts = <1 IRQ_TYPE_EDGE_FALLING>;
++			status = "okay";
++	};
++
++	ptn5110: tcpc@50 {
++		compatible = "nxp,ptn5110";
++		reg = <0x50>;
++		interrupt-parent = <&gpio3>;
++		interrupts = <27 IRQ_TYPE_LEVEL_LOW>;
++		status = "okay";
++
++		port {
++			typec1_dr_sw: endpoint {
++				remote-endpoint = <&usb1_drd_sw>;
++			};
++		};
++
++		typec1_con: connector {
++			compatible = "usb-c-connector";
++			label = "USB-C";
++			power-role = "dual";
++			data-role = "dual";
++			try-power-role = "sink";
++			source-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
++			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
++				     PDO_VAR(5000, 20000, 3000)>;
++			op-sink-microwatt = <15000000>;
++			self-powered;
++		};
++	};
++
++	ptn5110_2: tcpc@51 {
++		compatible = "nxp,ptn5110";
++		reg = <0x51>;
++		interrupt-parent = <&gpio3>;
++		interrupts = <27 IRQ_TYPE_LEVEL_LOW>;
++		status = "okay";
++
++		port {
++			typec2_dr_sw: endpoint {
++				remote-endpoint = <&usb2_drd_sw>;
++			};
++		};
++
++		typec2_con: connector {
++			compatible = "usb-c-connector";
++			label = "USB-C";
++			power-role = "dual";
++			data-role = "dual";
++			try-power-role = "sink";
++			source-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
++			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
++				     PDO_VAR(5000, 20000, 3000)>;
++			op-sink-microwatt = <15000000>;
++			self-powered;
++		};
++	};
++
++	adp5585_isp: mfd-isp@34 {
++		compatible = "adi,adp5585";
++		reg = <0x34>;
++		status = "okay";
++
++		adp5585gpio_isp: gpio-isp {
++			compatible = "adp5585-gpio";
++			gpio-controller;
++			#gpio-cells = <2>;
++		};
++
++		adp5585pwm_isp: pwm-isp {
++			compatible = "adp5585-pwm";
++			#pwm-cells = <3>;
++		};
++	};
++
++	ap1302: ap1302_mipi@3c {
++		compatible = "onsemi,ap1302";
++		reg = <0x3c>;
++		reset-gpios   = <&adp5585gpio 0 GPIO_ACTIVE_LOW>;
++		isp_en-gpios  = <&adp5585gpio_isp 2 GPIO_ACTIVE_HIGH>;
++		DVDD-supply   = <&reg_dvdd_1v2>;
++		VDDIO-supply  = <&reg_vddio_1v8>;
++		AVDD-supply   = <&reg_avdd_2v8>;
++		status = "okay";
++
++		port {
++			ar1302_mipi_ep: endpoint {
++				remote-endpoint = <&mipi_csi_ep>;
++			};
++		};
++	};
++};
++
++&lpuart1 { /* console */
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart1>;
++	status = "okay";
++};
++
++&lpuart5 {
++	/* BT */
++	pinctrl-names = "default";
++	pinctrl-assert-gpios = <&pcal6524 19 GPIO_ACTIVE_HIGH>;
++	pinctrl-0 = <&pinctrl_uart5>;
++	status = "okay";
++
++	bluetooth {
++		compatible = "nxp,88w8987-bt";
++	};
++};
++
++&media_blk_ctrl {
++	status = "okay";
++};
++
++&usbotg1 {
++	dr_mode = "otg";
++	hnp-disable;
++	srp-disable;
++	adp-disable;
++	usb-role-switch;
++	disable-over-current;
++	samsung,picophy-pre-emp-curr-control = <3>;
++	samsung,picophy-dc-vol-level-adjust = <7>;
++	status = "okay";
++
++	port {
++		usb1_drd_sw: endpoint {
++			remote-endpoint = <&typec1_dr_sw>;
++		};
++	};
++};
++
++&usbotg2 {
++	dr_mode = "otg";
++	hnp-disable;
++	srp-disable;
++	adp-disable;
++	usb-role-switch;
++	disable-over-current;
++	samsung,picophy-pre-emp-curr-control = <3>;
++	samsung,picophy-dc-vol-level-adjust = <7>;
++	status = "okay";
++
++	port {
++		usb2_drd_sw: endpoint {
++			remote-endpoint = <&typec2_dr_sw>;
++		};
++	};
++};
++
++&usdhc1 {
++	pinctrl-names = "default", "state_100mhz", "state_200mhz";
++	pinctrl-0 = <&pinctrl_usdhc1>;
++	pinctrl-1 = <&pinctrl_usdhc1_100mhz>;
++	pinctrl-2 = <&pinctrl_usdhc1_200mhz>;
++	bus-width = <8>;
++	non-removable;
++	status = "okay";
++};
++
++&usdhc2 {
++	pinctrl-names = "default", "state_100mhz", "state_200mhz", "sleep";
++	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-1 = <&pinctrl_usdhc2_100mhz>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-2 = <&pinctrl_usdhc2_200mhz>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-3 = <&pinctrl_usdhc2_sleep>, <&pinctrl_usdhc2_gpio_sleep>;
++	cd-gpios = <&gpio3 00 GPIO_ACTIVE_LOW>;
++	fsl,cd-gpio-wakeup-disable;
++	vmmc-supply = <&reg_usdhc2_vmmc>;
++	bus-width = <4>;
++	status = "okay";
++	no-sdio;
++	no-mmc;
++};
++
++&usdhc3 {
++	pinctrl-names = "default", "state_100mhz", "state_200mhz", "sleep";
++	pinctrl-0 = <&pinctrl_usdhc3>, <&pinctrl_usdhc3_wlan>;
++	pinctrl-1 = <&pinctrl_usdhc3_100mhz>, <&pinctrl_usdhc3_wlan>;
++	pinctrl-2 = <&pinctrl_usdhc3_200mhz>, <&pinctrl_usdhc3_wlan>;
++	pinctrl-3 = <&pinctrl_usdhc3_sleep>, <&pinctrl_usdhc3_wlan>;
++	mmc-pwrseq = <&usdhc3_pwrseq>;
++	vmmc-supply = <&reg_usdhc3_vmmc>;
++	pinctrl-assert-gpios = <&pcal6524 13 GPIO_ACTIVE_HIGH>;
++	bus-width = <4>;
++	keep-power-in-suspend;
++	non-removable;
++	wakeup-source;
++	fsl,sdio-async-interrupt-enabled;
++	status = "okay";
++
++	wifi_wake_host {
++		compatible = "nxp,wifi-wake-host";
++		interrupt-parent = <&gpio3>;
++		interrupts = <26 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-names = "host-wake";
++	};
++};
++
++&wdog3 {
++	status = "okay";
++};
++
++&iomuxc {
++	pinctrl_eqos: eqosgrp {
++		fsl,pins = <
++			MX93_PAD_ENET1_MDC__ENET_QOS_MDC			0x57e
++			MX93_PAD_ENET1_MDIO__ENET_QOS_MDIO			0x57e
++			MX93_PAD_ENET1_RD0__ENET_QOS_RGMII_RD0			0x57e
++			MX93_PAD_ENET1_RD1__ENET_QOS_RGMII_RD1			0x57e
++			MX93_PAD_ENET1_RD2__ENET_QOS_RGMII_RD2			0x57e
++			MX93_PAD_ENET1_RD3__ENET_QOS_RGMII_RD3			0x57e
++			MX93_PAD_ENET1_RXC__CCM_ENET_QOS_CLOCK_GENERATE_RX_CLK	0x5fe
++			MX93_PAD_ENET1_RX_CTL__ENET_QOS_RGMII_RX_CTL		0x57e
++			MX93_PAD_ENET1_TD0__ENET_QOS_RGMII_TD0			0x57e
++			MX93_PAD_ENET1_TD1__ENET_QOS_RGMII_TD1			0x57e
++			MX93_PAD_ENET1_TD2__ENET_QOS_RGMII_TD2			0x57e
++			MX93_PAD_ENET1_TD3__ENET_QOS_RGMII_TD3			0x57e
++			MX93_PAD_ENET1_TXC__CCM_ENET_QOS_CLOCK_GENERATE_TX_CLK	0x5fe
++			MX93_PAD_ENET1_TX_CTL__ENET_QOS_RGMII_TX_CTL		0x57e
++		>;
++	};
++
++	pinctrl_eqos_sleep: eqosgrpsleep {
++		fsl,pins = <
++			MX93_PAD_ENET1_MDC__GPIO4_IO00				0x31e
++			MX93_PAD_ENET1_MDIO__GPIO4_IO01				0x31e
++			MX93_PAD_ENET1_RD0__GPIO4_IO10                          0x31e
++			MX93_PAD_ENET1_RD1__GPIO4_IO11				0x31e
++			MX93_PAD_ENET1_RD2__GPIO4_IO12				0x31e
++			MX93_PAD_ENET1_RD3__GPIO4_IO13				0x31e
++			MX93_PAD_ENET1_RXC__GPIO4_IO09                          0x31e
++			MX93_PAD_ENET1_RX_CTL__GPIO4_IO08			0x31e
++			MX93_PAD_ENET1_TD0__GPIO4_IO05                          0x31e
++			MX93_PAD_ENET1_TD1__GPIO4_IO04                          0x31e
++			MX93_PAD_ENET1_TD2__GPIO4_IO03				0x31e
++			MX93_PAD_ENET1_TD3__GPIO4_IO02				0x31e
++			MX93_PAD_ENET1_TXC__GPIO4_IO07                          0x31e
++			MX93_PAD_ENET1_TX_CTL__GPIO4_IO06                       0x31e
++		>;
++	};
++
++	pinctrl_fec: fecgrp {
++		fsl,pins = <
++			MX93_PAD_ENET2_MDC__ENET1_MDC			0x57e
++			MX93_PAD_ENET2_MDIO__ENET1_MDIO			0x57e
++			MX93_PAD_ENET2_RD0__ENET1_RGMII_RD0		0x57e
++			MX93_PAD_ENET2_RD1__ENET1_RGMII_RD1		0x57e
++			MX93_PAD_ENET2_RD2__ENET1_RGMII_RD2		0x57e
++			MX93_PAD_ENET2_RD3__ENET1_RGMII_RD3		0x57e
++			MX93_PAD_ENET2_RXC__ENET1_RGMII_RXC		0x5fe
++			MX93_PAD_ENET2_RX_CTL__ENET1_RGMII_RX_CTL	0x57e
++			MX93_PAD_ENET2_TD0__ENET1_RGMII_TD0		0x57e
++			MX93_PAD_ENET2_TD1__ENET1_RGMII_TD1		0x57e
++			MX93_PAD_ENET2_TD2__ENET1_RGMII_TD2		0x57e
++			MX93_PAD_ENET2_TD3__ENET1_RGMII_TD3		0x57e
++			MX93_PAD_ENET2_TXC__ENET1_RGMII_TXC		0x5fe
++			MX93_PAD_ENET2_TX_CTL__ENET1_RGMII_TX_CTL	0x57e
++		>;
++	};
++
++	pinctrl_fec_sleep: fecsleepgrp {
++		fsl,pins = <
++			MX93_PAD_ENET2_MDC__GPIO4_IO14			0x51e
++			MX93_PAD_ENET2_MDIO__GPIO4_IO15			0x51e
++			MX93_PAD_ENET2_RD0__GPIO4_IO24			0x51e
++			MX93_PAD_ENET2_RD1__GPIO4_IO25			0x51e
++			MX93_PAD_ENET2_RD2__GPIO4_IO26			0x51e
++			MX93_PAD_ENET2_RD3__GPIO4_IO27			0x51e
++			MX93_PAD_ENET2_RXC__GPIO4_IO23                  0x51e
++			MX93_PAD_ENET2_RX_CTL__GPIO4_IO22		0x51e
++			MX93_PAD_ENET2_TD0__GPIO4_IO19			0x51e
++			MX93_PAD_ENET2_TD1__GPIO4_IO18			0x51e
++			MX93_PAD_ENET2_TD2__GPIO4_IO17			0x51e
++			MX93_PAD_ENET2_TD3__GPIO4_IO16			0x51e
++			MX93_PAD_ENET2_TXC__GPIO4_IO21                  0x51e
++			MX93_PAD_ENET2_TX_CTL__GPIO4_IO20               0x51e
++		>;
++	};
++
++	pinctrl_flexcan2: flexcan2grp {
++		fsl,pins = <
++			MX93_PAD_GPIO_IO25__CAN2_TX	0x139e
++			MX93_PAD_GPIO_IO27__CAN2_RX	0x139e
++		>;
++	};
++	pinctrl_flexcan2_sleep: flexcan2sleepgrp {
++		fsl,pins = <
++			MX93_PAD_GPIO_IO25__GPIO2_IO25  0x31e
++			MX93_PAD_GPIO_IO27__GPIO2_IO27	0x31e
++		>;
++	};
++
++
++	pinctrl_lpi2c1: lpi2c1grp {
++		fsl,pins = <
++			MX93_PAD_I2C1_SCL__LPI2C1_SCL			0x40000b9e
++			MX93_PAD_I2C1_SDA__LPI2C1_SDA			0x40000b9e
++		>;
++	};
++
++	pinctrl_lpi2c2: lpi2c2grp {
++		fsl,pins = <
++			MX93_PAD_I2C2_SCL__LPI2C2_SCL			0x40000b9e
++			MX93_PAD_I2C2_SDA__LPI2C2_SDA			0x40000b9e
++		>;
++	};
++
++	pinctrl_lpi2c3: lpi2c3grp {
++		fsl,pins = <
++			MX93_PAD_GPIO_IO28__LPI2C3_SDA			0x40000b9e
++			MX93_PAD_GPIO_IO29__LPI2C3_SCL			0x40000b9e
++		>;
++	};
++
++	pinctrl_pcal6524: pcal6524grp {
++		fsl,pins = <
++			MX93_PAD_CCM_CLKO2__GPIO3_IO27			0x31e
++		>;
++	};
++
++	pinctrl_uart1: uart1grp {
++		fsl,pins = <
++			MX93_PAD_UART1_RXD__LPUART1_RX			0x31e
++			MX93_PAD_UART1_TXD__LPUART1_TX			0x31e
++		>;
++	};
++
++	pinctrl_uart5: uart5grp {
++		fsl,pins = <
++			MX93_PAD_DAP_TDO_TRACESWO__LPUART5_TX	0x31e
++			MX93_PAD_DAP_TDI__LPUART5_RX		0x31e
++			MX93_PAD_DAP_TMS_SWDIO__LPUART5_RTS_B	0x31e
++			MX93_PAD_DAP_TCLK_SWCLK__LPUART5_CTS_B	0x31e
++		>;
++	};
++
++	/* need to config the SION for data and cmd pad, refer to ERR052021 */
++	pinctrl_usdhc1: usdhc1grp {
++		fsl,pins = <
++			MX93_PAD_SD1_CLK__USDHC1_CLK		0x1582
++			MX93_PAD_SD1_CMD__USDHC1_CMD		0x40001382
++			MX93_PAD_SD1_DATA0__USDHC1_DATA0	0x40001382
++			MX93_PAD_SD1_DATA1__USDHC1_DATA1	0x40001382
++			MX93_PAD_SD1_DATA2__USDHC1_DATA2	0x40001382
++			MX93_PAD_SD1_DATA3__USDHC1_DATA3	0x40001382
++			MX93_PAD_SD1_DATA4__USDHC1_DATA4	0x40001382
++			MX93_PAD_SD1_DATA5__USDHC1_DATA5	0x40001382
++			MX93_PAD_SD1_DATA6__USDHC1_DATA6	0x40001382
++			MX93_PAD_SD1_DATA7__USDHC1_DATA7	0x40001382
++			MX93_PAD_SD1_STROBE__USDHC1_STROBE	0x1582
++		>;
++	};
++
++	/* need to config the SION for data and cmd pad, refer to ERR052021 */
++	pinctrl_usdhc1_100mhz: usdhc1-100mhzgrp {
++		fsl,pins = <
++			MX93_PAD_SD1_CLK__USDHC1_CLK		0x158e
++			MX93_PAD_SD1_CMD__USDHC1_CMD		0x4000138e
++			MX93_PAD_SD1_DATA0__USDHC1_DATA0	0x4000138e
++			MX93_PAD_SD1_DATA1__USDHC1_DATA1	0x4000138e
++			MX93_PAD_SD1_DATA2__USDHC1_DATA2	0x4000138e
++			MX93_PAD_SD1_DATA3__USDHC1_DATA3	0x4000138e
++			MX93_PAD_SD1_DATA4__USDHC1_DATA4	0x4000138e
++			MX93_PAD_SD1_DATA5__USDHC1_DATA5	0x4000138e
++			MX93_PAD_SD1_DATA6__USDHC1_DATA6	0x4000138e
++			MX93_PAD_SD1_DATA7__USDHC1_DATA7	0x4000138e
++			MX93_PAD_SD1_STROBE__USDHC1_STROBE	0x158e
++		>;
++	};
++
++	/* need to config the SION for data and cmd pad, refer to ERR052021 */
++	pinctrl_usdhc1_200mhz: usdhc1-200mhzgrp {
++		fsl,pins = <
++			MX93_PAD_SD1_CLK__USDHC1_CLK		0x15fe
++			MX93_PAD_SD1_CMD__USDHC1_CMD		0x400013fe
++			MX93_PAD_SD1_DATA0__USDHC1_DATA0	0x400013fe
++			MX93_PAD_SD1_DATA1__USDHC1_DATA1	0x400013fe
++			MX93_PAD_SD1_DATA2__USDHC1_DATA2	0x400013fe
++			MX93_PAD_SD1_DATA3__USDHC1_DATA3	0x400013fe
++			MX93_PAD_SD1_DATA4__USDHC1_DATA4	0x400013fe
++			MX93_PAD_SD1_DATA5__USDHC1_DATA5	0x400013fe
++			MX93_PAD_SD1_DATA6__USDHC1_DATA6	0x400013fe
++			MX93_PAD_SD1_DATA7__USDHC1_DATA7	0x400013fe
++			MX93_PAD_SD1_STROBE__USDHC1_STROBE	0x15fe
++		>;
++	};
++
++	pinctrl_reg_usdhc2_vmmc: regusdhc2vmmcgrp {
++		fsl,pins = <
++			MX93_PAD_SD2_RESET_B__GPIO3_IO07	0x31e
++		>;
++	};
++
++	pinctrl_usdhc2_gpio: usdhc2gpiogrp {
++		fsl,pins = <
++			MX93_PAD_SD2_CD_B__GPIO3_IO00		0x31e
++		>;
++	};
++
++	pinctrl_usdhc2_gpio_sleep: usdhc2gpiogrpsleep {
++		fsl,pins = <
++			MX93_PAD_SD2_CD_B__GPIO3_IO00		0x51e
++		>;
++	};
++
++	/* need to config the SION for data and cmd pad, refer to ERR052021 */
++	pinctrl_usdhc2: usdhc2grp {
++		fsl,pins = <
++			MX93_PAD_SD2_CLK__USDHC2_CLK		0x1582
++			MX93_PAD_SD2_CMD__USDHC2_CMD		0x40001382
++			MX93_PAD_SD2_DATA0__USDHC2_DATA0	0x40001382
++			MX93_PAD_SD2_DATA1__USDHC2_DATA1	0x40001382
++			MX93_PAD_SD2_DATA2__USDHC2_DATA2	0x40001382
++			MX93_PAD_SD2_DATA3__USDHC2_DATA3	0x40001382
++			MX93_PAD_SD2_VSELECT__USDHC2_VSELECT	0x51e
++		>;
++	};
++
++	/* need to config the SION for data and cmd pad, refer to ERR052021 */
++	pinctrl_usdhc2_100mhz: usdhc2-100mhzgrp {
++		fsl,pins = <
++			MX93_PAD_SD2_CLK__USDHC2_CLK		0x158e
++			MX93_PAD_SD2_CMD__USDHC2_CMD		0x4000138e
++			MX93_PAD_SD2_DATA0__USDHC2_DATA0	0x4000138e
++			MX93_PAD_SD2_DATA1__USDHC2_DATA1	0x4000138e
++			MX93_PAD_SD2_DATA2__USDHC2_DATA2	0x4000138e
++			MX93_PAD_SD2_DATA3__USDHC2_DATA3	0x4000138e
++			MX93_PAD_SD2_VSELECT__USDHC2_VSELECT	0x51e
++		>;
++	};
++
++	/* need to config the SION for data and cmd pad, refer to ERR052021 */
++	pinctrl_usdhc2_200mhz: usdhc2-200mhzgrp {
++		fsl,pins = <
++			MX93_PAD_SD2_CLK__USDHC2_CLK		0x15fe
++			MX93_PAD_SD2_CMD__USDHC2_CMD		0x400013fe
++			MX93_PAD_SD2_DATA0__USDHC2_DATA0	0x400013fe
++			MX93_PAD_SD2_DATA1__USDHC2_DATA1	0x400013fe
++			MX93_PAD_SD2_DATA2__USDHC2_DATA2	0x400013fe
++			MX93_PAD_SD2_DATA3__USDHC2_DATA3	0x400013fe
++			MX93_PAD_SD2_VSELECT__USDHC2_VSELECT	0x51e
++		>;
++	};
++
++	pinctrl_usdhc2_sleep: usdhc2grpsleep {
++		fsl,pins = <
++			MX93_PAD_SD2_CLK__GPIO3_IO01            0x51e
++			MX93_PAD_SD2_CMD__GPIO3_IO02		0x51e
++			MX93_PAD_SD2_DATA0__GPIO3_IO03		0x51e
++			MX93_PAD_SD2_DATA1__GPIO3_IO04		0x51e
++			MX93_PAD_SD2_DATA2__GPIO3_IO05		0x51e
++			MX93_PAD_SD2_DATA3__GPIO3_IO06		0x51e
++			MX93_PAD_SD2_VSELECT__GPIO3_IO19	0x51e
++		>;
++	};
++
++	/* need to config the SION for data and cmd pad, refer to ERR052021 */
++	pinctrl_usdhc3: usdhc3grp {
++		fsl,pins = <
++			MX93_PAD_SD3_CLK__USDHC3_CLK		0x1582
++			MX93_PAD_SD3_CMD__USDHC3_CMD		0x40001382
++			MX93_PAD_SD3_DATA0__USDHC3_DATA0	0x40001382
++			MX93_PAD_SD3_DATA1__USDHC3_DATA1	0x40001382
++			MX93_PAD_SD3_DATA2__USDHC3_DATA2	0x40001382
++			MX93_PAD_SD3_DATA3__USDHC3_DATA3	0x40001382
++		>;
++	};
++
++	/* need to config the SION for data and cmd pad, refer to ERR052021 */
++	pinctrl_usdhc3_100mhz: usdhc3-100mhzgrp {
++		fsl,pins = <
++			MX93_PAD_SD3_CLK__USDHC3_CLK		0x158e
++			MX93_PAD_SD3_CMD__USDHC3_CMD		0x4000138e
++			MX93_PAD_SD3_DATA0__USDHC3_DATA0	0x4000138e
++			MX93_PAD_SD3_DATA1__USDHC3_DATA1	0x4000138e
++			MX93_PAD_SD3_DATA2__USDHC3_DATA2	0x4000138e
++			MX93_PAD_SD3_DATA3__USDHC3_DATA3	0x4000138e
++		>;
++	};
++
++	/* need to config the SION for data and cmd pad, refer to ERR052021 */
++	pinctrl_usdhc3_200mhz: usdhc3-200mhzgrp {
++		fsl,pins = <
++			MX93_PAD_SD3_CLK__USDHC3_CLK		0x15fe
++			MX93_PAD_SD3_CMD__USDHC3_CMD		0x400013fe
++			MX93_PAD_SD3_DATA0__USDHC3_DATA0	0x400013fe
++			MX93_PAD_SD3_DATA1__USDHC3_DATA1	0x400013fe
++			MX93_PAD_SD3_DATA2__USDHC3_DATA2	0x400013fe
++			MX93_PAD_SD3_DATA3__USDHC3_DATA3	0x400013fe
++		>;
++	};
++
++	pinctrl_usdhc3_sleep: usdhc3grpsleep {
++		fsl,pins = <
++			MX93_PAD_SD3_CLK__GPIO3_IO20		0x31e
++			MX93_PAD_SD3_CMD__GPIO3_IO21		0x31e
++			MX93_PAD_SD3_DATA0__GPIO3_IO22		0x31e
++			MX93_PAD_SD3_DATA1__GPIO3_IO23		0x31e
++			MX93_PAD_SD3_DATA2__GPIO3_IO24		0x31e
++			MX93_PAD_SD3_DATA3__GPIO3_IO25		0x31e
++		>;
++	};
++
++	pinctrl_usdhc3_wlan: usdhc3wlangrp {
++		fsl,pins = <
++			MX93_PAD_CCM_CLKO1__GPIO3_IO26		0x31e
++		>;
++	};
++
++	pinctrl_sai1: sai1grp {
++		fsl,pins = <
++			MX93_PAD_SAI1_TXC__SAI1_TX_BCLK			0x31e
++			MX93_PAD_SAI1_TXFS__SAI1_TX_SYNC		0x31e
++			MX93_PAD_SAI1_TXD0__SAI1_TX_DATA00		0x31e
++			MX93_PAD_SAI1_RXD0__SAI1_RX_DATA00		0x31e
++		>;
++	};
++
++	pinctrl_sai1_sleep: sai1grpsleep {
++		fsl,pins = <
++			MX93_PAD_SAI1_TXC__GPIO1_IO12                   0x51e
++			MX93_PAD_SAI1_TXFS__GPIO1_IO11			0x51e
++			MX93_PAD_SAI1_TXD0__GPIO1_IO13			0x51e
++			MX93_PAD_SAI1_RXD0__GPIO1_IO14			0x51e
++		>;
++	};
++
++	pinctrl_sai3: sai3grp {
++		fsl,pins = <
++			MX93_PAD_GPIO_IO26__SAI3_TX_SYNC		0x31e
++			MX93_PAD_GPIO_IO16__SAI3_TX_BCLK		0x31e
++			MX93_PAD_GPIO_IO17__SAI3_MCLK			0x31e
++			MX93_PAD_GPIO_IO19__SAI3_TX_DATA00		0x31e
++			MX93_PAD_GPIO_IO20__SAI3_RX_DATA00		0x31e
++		>;
++	};
++
++	pinctrl_sai3_sleep: sai3grpsleep {
++		fsl,pins = <
++			MX93_PAD_GPIO_IO26__GPIO2_IO26			0x51e
++			MX93_PAD_GPIO_IO16__GPIO2_IO16			0x51e
++			MX93_PAD_GPIO_IO17__GPIO2_IO17			0x51e
++			MX93_PAD_GPIO_IO19__GPIO2_IO19			0x51e
++			MX93_PAD_GPIO_IO20__GPIO2_IO20			0x51e
++		>;
++	};
++
++	pinctrl_pdm: pdmgrp {
++		fsl,pins = <
++			MX93_PAD_PDM_CLK__PDM_CLK			0x31e
++			MX93_PAD_PDM_BIT_STREAM0__PDM_BIT_STREAM00	0x31e
++			MX93_PAD_PDM_BIT_STREAM1__PDM_BIT_STREAM01	0x31e
++		>;
++	};
++
++	pinctrl_pdm_sleep: pdmgrpsleep {
++		fsl,pins = <
++			MX93_PAD_PDM_CLK__GPIO1_IO08			0x31e
++			MX93_PAD_PDM_BIT_STREAM0__GPIO1_IO09		0x31e
++			MX93_PAD_PDM_BIT_STREAM1__GPIO1_IO10		0x31e
++		>;
++	};
++
++	pinctrl_spdif: spdifgrp {
++		fsl,pins = <
++			MX93_PAD_GPIO_IO22__SPDIF_IN		0x31e
++			MX93_PAD_GPIO_IO23__SPDIF_OUT		0x31e
++		>;
++	};
++
++	pinctrl_spdif_sleep: spdifgrpsleep {
++		fsl,pins = <
++			MX93_PAD_GPIO_IO22__GPIO2_IO22		0x31e
++			MX93_PAD_GPIO_IO23__GPIO2_IO23		0x31e
++		>;
++	};
++};
++
++&epxp {
++	status = "okay";
++};
++
++&cameradev {
++	status = "okay";
++};
++
++&isi_0 {
++	status = "okay";
++
++	cap_device {
++		status = "okay";
++	};
++};
++
++&mipi_csi {
++	status = "okay";
++
++	port {
++		mipi_csi_ep: endpoint {
++			remote-endpoint = <&ar1302_mipi_ep>;
++			data-lanes = <2>;
++			cfg-clk-range = <28>;
++			hs-clk-range = <0x2b>;
++			bus-type = <4>;
++		};
++	};
++};
+-- 
+2.30.2
+

--- a/recipes-kernel/linux/linux-fslc-imx_6.6.bbappend
+++ b/recipes-kernel/linux/linux-fslc-imx_6.6.bbappend
@@ -6,4 +6,5 @@ SRC_URI += " \
     file://0002-spi-add-m95m04-to-spidev.patch \
     file://0003-driver-net-phy-config-eth-phy-behavior.patch \
     file://0004-gpu-drm-bridge-revert-d89078c37b10f05fa4f4791b71db25.patch \
+    file://0005-arm64-boot-dts-iesy-add-support-for-iesy-imx93-eva-m.patch \
 "


### PR DESCRIPTION
Configured PMIC for u-boot and kernel with voltages according to datasheet. moved pmic from i2c bus 2 to bus 1. added new devicetree for iesy imx93 eva mi to kernel 