### PR TITLE
i.MX93 EVA MI: add MikroBus EEPROM on I2C-A

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx/0022-arm64-boot-dts-iesy-add-click-eeprom-on-I2C-A.patch
+++ b/recipes-kernel/linux/linux-fslc-imx/0022-arm64-boot-dts-iesy-add-click-eeprom-on-I2C-A.patch
@@ -1,0 +1,31 @@
+From 7d3248a59b78ea7b7bbfafc87ccbbf5d37dac794 Mon Sep 17 00:00:00 2001
+From: EliaFunk <eli@iesy.com>
+Date: Tue, 10 Sep 2024 11:13:51 +0200
+Subject: [PATCH 22/22] arm64: boot: dts: iesy: add click eeprom on I2C-A
+
+add MikroBus click module eeprom on I2C-A
+---
+ arch/arm64/boot/dts/iesy/iesy-imx93-eva-mi-v1.dts | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/iesy/iesy-imx93-eva-mi-v1.dts b/arch/arm64/boot/dts/iesy/iesy-imx93-eva-mi-v1.dts
+index 4f8b8d0b6fb9..b522a3268d17 100644
+--- a/arch/arm64/boot/dts/iesy/iesy-imx93-eva-mi-v1.dts
++++ b/arch/arm64/boot/dts/iesy/iesy-imx93-eva-mi-v1.dts
+@@ -428,6 +428,13 @@ eeprom@53 {
+ 		vcc-supply = <&reg_1v8_carrier>;
+ 	};
+ 
++	/* MikroBus EEPROM Click */
++	eeprom@54 {
++		compatible = "atmel,24c08";
++		reg = <0x54>;
++		pagesize = <8>;
++	};
++
+ 	lsm6dsm@6a {
+ 		compatible = "st,lsm6dso";
+ 		reg = <0x6a>;
+-- 
+2.30.2
+

--- a/recipes-kernel/linux/linux-fslc-imx_6.6.bbappend
+++ b/recipes-kernel/linux/linux-fslc-imx_6.6.bbappend
@@ -23,4 +23,5 @@ SRC_URI += " \
     file://0019-arm64-boot-dts-add-mc3630-on-spi-A.patch \
     file://0020-arm64-boot-dts-iesy-move-adc-node-and-regulator-to-s.patch \
     file://0021-arm64-boot-dts-iesy-add-usb-b-and-usb-d-functionalit.patch \
+    file://0022-arm64-boot-dts-iesy-add-click-eeprom-on-I2C-A.patch \
 "


### PR DESCRIPTION
add MikroBus click module eeprom on I2C-A