### PR TITLE
i.MX93 EVA MI: add support for SDIO-B

### DIFF
--- a/conf/machine/iesy-imx93-eva-mi.conf
+++ b/conf/machine/iesy-imx93-eva-mi.conf
@@ -19,3 +19,9 @@ BBMASK += " \
 	"
 # should be removed once the cause for why the nxp weston versions do not work is found out
 BBMASK += "meta-freescale/recipes-graphics/wayland/weston_.*\.imx\.bb"
+
+MACHINE_FEATURES:append = " nxp9098-sdio"
+
+KERNEL_MODULE_AUTOLOAD += "moal"
+KERNEL_MODULE_PROBECONF += "moal"
+module_conf_moal = "options moal mod_para=nxp/wifi_mod_para.conf"

--- a/recipes-kernel/linux/linux-fslc-imx/0026-arm64-dts-iesy-add-support-for-sdio-b.patch
+++ b/recipes-kernel/linux/linux-fslc-imx/0026-arm64-dts-iesy-add-support-for-sdio-b.patch
@@ -1,0 +1,254 @@
+From 889bcc7f13b2c672f09e6613a7555873fa13325f Mon Sep 17 00:00:00 2001
+From: EliaFunk <eli@iesy.com>
+Date: Fri, 20 Sep 2024 12:19:44 +0200
+Subject: [PATCH 26/27] arm64: dts: iesy: add support for sdio-b
+
+add support for SDIO-B to i.mx93 module
+---
+ .../boot/dts/iesy/iesy-imx93-eva-mi-v1.dts    | 98 -------------------
+ .../boot/dts/iesy/iesy-imx93-osm-mf.dtsi      | 80 ++++++++++++++-
+ 2 files changed, 78 insertions(+), 100 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/iesy/iesy-imx93-eva-mi-v1.dts b/arch/arm64/boot/dts/iesy/iesy-imx93-eva-mi-v1.dts
+index 231a8b140f63..9e2b6e7bb1bf 100644
+--- a/arch/arm64/boot/dts/iesy/iesy-imx93-eva-mi-v1.dts
++++ b/arch/arm64/boot/dts/iesy/iesy-imx93-eva-mi-v1.dts
+@@ -106,27 +106,6 @@ reg_vdd_12v: regulator-vdd-12v {
+ 		enable-active-high;
+ 	};
+ 
+-	reg_usdhc3_vmmc: regulator-usdhc3 {
+-		compatible = "regulator-fixed";
+-		regulator-name = "WLAN_EN";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		gpio = <&pcal6524 20 GPIO_ACTIVE_HIGH>;
+-		/*
+-		 * IW612 wifi chip needs more delay than other wifi chips to complete
+-		 * the host interface initialization after power up, otherwise the
+-		 * internal state of IW612 may be unstable, resulting in the failure of
+-		 * the SDIO3.0 switch voltage.
+-		 */
+-		startup-delay-us = <20000>;
+-		enable-active-high;
+-	};
+-
+-	usdhc3_pwrseq: usdhc3_pwrseq {
+-		compatible = "mmc-pwrseq-simple";
+-		reset-gpios = <&pcal6524 12 GPIO_ACTIVE_LOW>;
+-	};
+-
+ 	reg_dvdd_sel: regulator-dvdd_sel {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "DVDD_SEL";
+@@ -509,30 +488,6 @@ &usbotg1 {
+ 	status = "okay";
+ };
+ 
+-&usdhc3 {
+-	pinctrl-names = "default", "state_100mhz", "state_200mhz", "sleep";
+-	pinctrl-0 = <&pinctrl_usdhc3>, <&pinctrl_usdhc3_wlan>;
+-	pinctrl-1 = <&pinctrl_usdhc3_100mhz>, <&pinctrl_usdhc3_wlan>;
+-	pinctrl-2 = <&pinctrl_usdhc3_200mhz>, <&pinctrl_usdhc3_wlan>;
+-	pinctrl-3 = <&pinctrl_usdhc3_sleep>, <&pinctrl_usdhc3_wlan>;
+-	mmc-pwrseq = <&usdhc3_pwrseq>;
+-	vmmc-supply = <&reg_usdhc3_vmmc>;
+-	pinctrl-assert-gpios = <&pcal6524 13 GPIO_ACTIVE_HIGH>;
+-	bus-width = <4>;
+-	keep-power-in-suspend;
+-	non-removable;
+-	wakeup-source;
+-	fsl,sdio-async-interrupt-enabled;
+-	status = "okay";
+-
+-	wifi_wake_host {
+-		compatible = "nxp,wifi-wake-host";
+-		interrupt-parent = <&gpio3>;
+-		interrupts = <26 IRQ_TYPE_LEVEL_LOW>;
+-		interrupt-names = "host-wake";
+-	};
+-};
+-
+ &wdog3 {
+ 	status = "okay";
+ };
+@@ -586,59 +541,6 @@ MX93_PAD_SD2_RESET_B__GPIO3_IO07	0x31e
+ 		>;
+ 	};
+ 
+-	/* need to config the SION for data and cmd pad, refer to ERR052021 */
+-	pinctrl_usdhc3: usdhc3grp {
+-		fsl,pins = <
+-			MX93_PAD_SD3_CLK__USDHC3_CLK		0x1582
+-			MX93_PAD_SD3_CMD__USDHC3_CMD		0x40001382
+-			MX93_PAD_SD3_DATA0__USDHC3_DATA0	0x40001382
+-			MX93_PAD_SD3_DATA1__USDHC3_DATA1	0x40001382
+-			MX93_PAD_SD3_DATA2__USDHC3_DATA2	0x40001382
+-			MX93_PAD_SD3_DATA3__USDHC3_DATA3	0x40001382
+-		>;
+-	};
+-
+-	/* need to config the SION for data and cmd pad, refer to ERR052021 */
+-	pinctrl_usdhc3_100mhz: usdhc3-100mhzgrp {
+-		fsl,pins = <
+-			MX93_PAD_SD3_CLK__USDHC3_CLK		0x158e
+-			MX93_PAD_SD3_CMD__USDHC3_CMD		0x4000138e
+-			MX93_PAD_SD3_DATA0__USDHC3_DATA0	0x4000138e
+-			MX93_PAD_SD3_DATA1__USDHC3_DATA1	0x4000138e
+-			MX93_PAD_SD3_DATA2__USDHC3_DATA2	0x4000138e
+-			MX93_PAD_SD3_DATA3__USDHC3_DATA3	0x4000138e
+-		>;
+-	};
+-
+-	/* need to config the SION for data and cmd pad, refer to ERR052021 */
+-	pinctrl_usdhc3_200mhz: usdhc3-200mhzgrp {
+-		fsl,pins = <
+-			MX93_PAD_SD3_CLK__USDHC3_CLK		0x15fe
+-			MX93_PAD_SD3_CMD__USDHC3_CMD		0x400013fe
+-			MX93_PAD_SD3_DATA0__USDHC3_DATA0	0x400013fe
+-			MX93_PAD_SD3_DATA1__USDHC3_DATA1	0x400013fe
+-			MX93_PAD_SD3_DATA2__USDHC3_DATA2	0x400013fe
+-			MX93_PAD_SD3_DATA3__USDHC3_DATA3	0x400013fe
+-		>;
+-	};
+-
+-	pinctrl_usdhc3_sleep: usdhc3grpsleep {
+-		fsl,pins = <
+-			MX93_PAD_SD3_CLK__GPIO3_IO20		0x31e
+-			MX93_PAD_SD3_CMD__GPIO3_IO21		0x31e
+-			MX93_PAD_SD3_DATA0__GPIO3_IO22		0x31e
+-			MX93_PAD_SD3_DATA1__GPIO3_IO23		0x31e
+-			MX93_PAD_SD3_DATA2__GPIO3_IO24		0x31e
+-			MX93_PAD_SD3_DATA3__GPIO3_IO25		0x31e
+-		>;
+-	};
+-
+-	pinctrl_usdhc3_wlan: usdhc3wlangrp {
+-		fsl,pins = <
+-			MX93_PAD_CCM_CLKO1__GPIO3_IO26		0x31e
+-		>;
+-	};
+-
+ 	pinctrl_sai3: sai3grp {
+ 		fsl,pins = <
+ 			MX93_PAD_GPIO_IO26__SAI3_TX_SYNC		0x31e
+diff --git a/arch/arm64/boot/dts/iesy/iesy-imx93-osm-mf.dtsi b/arch/arm64/boot/dts/iesy/iesy-imx93-osm-mf.dtsi
+index fe9ec2dd3acb..ba7c10f1f4fc 100644
+--- a/arch/arm64/boot/dts/iesy/iesy-imx93-osm-mf.dtsi
++++ b/arch/arm64/boot/dts/iesy/iesy-imx93-osm-mf.dtsi
+@@ -22,6 +22,20 @@ reg_vref_1v8: regulator-adc-vref {
+ 		regulator-max-microvolt = <1800000>;
+ 	};
+ 
++	reg_usdhc3_vmmc: regulator-usdhc3 {
++		compatible = "regulator-fixed";
++		regulator-name = "WLAN_EN";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <100>;
++		off-on-delay-us = <20000>;
++		enable-active-high;
++	};
++
++	usdhc3_pwrseq: usdhc3_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++	};
++
+     reserved-memory {
+ 		#address-cells = <2>;
+ 		#size-cells = <2>;
+@@ -372,6 +386,53 @@ MX93_PAD_SD2_DATA3__GPIO3_IO06		0x51e
+ 			MX93_PAD_SD2_VSELECT__GPIO3_IO19	0x51e
+ 		>;
+ 	};
++
++	/* need to config the SION for data and cmd pad, refer to ERR052021 */
++	pinctrl_usdhc3: usdhc3grp {
++		fsl,pins = <
++			MX93_PAD_SD3_CLK__USDHC3_CLK		0x1582
++			MX93_PAD_SD3_CMD__USDHC3_CMD		0x40001382
++			MX93_PAD_SD3_DATA0__USDHC3_DATA0	0x40001382
++			MX93_PAD_SD3_DATA1__USDHC3_DATA1	0x40001382
++			MX93_PAD_SD3_DATA2__USDHC3_DATA2	0x40001382
++			MX93_PAD_SD3_DATA3__USDHC3_DATA3	0x40001382
++		>;
++	};
++
++	/* need to config the SION for data and cmd pad, refer to ERR052021 */
++	pinctrl_usdhc3_100mhz: usdhc3-100mhzgrp {
++		fsl,pins = <
++			MX93_PAD_SD3_CLK__USDHC3_CLK		0x158e
++			MX93_PAD_SD3_CMD__USDHC3_CMD		0x4000138e
++			MX93_PAD_SD3_DATA0__USDHC3_DATA0	0x4000138e
++			MX93_PAD_SD3_DATA1__USDHC3_DATA1	0x4000138e
++			MX93_PAD_SD3_DATA2__USDHC3_DATA2	0x4000138e
++			MX93_PAD_SD3_DATA3__USDHC3_DATA3	0x4000138e
++		>;
++	};
++
++	/* need to config the SION for data and cmd pad, refer to ERR052021 */
++	pinctrl_usdhc3_200mhz: usdhc3-200mhzgrp {
++		fsl,pins = <
++			MX93_PAD_SD3_CLK__USDHC3_CLK		0x15fe
++			MX93_PAD_SD3_CMD__USDHC3_CMD		0x400013fe
++			MX93_PAD_SD3_DATA0__USDHC3_DATA0	0x400013fe
++			MX93_PAD_SD3_DATA1__USDHC3_DATA1	0x400013fe
++			MX93_PAD_SD3_DATA2__USDHC3_DATA2	0x400013fe
++			MX93_PAD_SD3_DATA3__USDHC3_DATA3	0x400013fe
++		>;
++	};
++
++	pinctrl_usdhc3_sleep: usdhc3grpsleep {
++		fsl,pins = <
++			MX93_PAD_SD3_CLK__GPIO3_IO20		0x31e
++			MX93_PAD_SD3_CMD__GPIO3_IO21		0x31e
++			MX93_PAD_SD3_DATA0__GPIO3_IO22		0x31e
++			MX93_PAD_SD3_DATA1__GPIO3_IO23		0x31e
++			MX93_PAD_SD3_DATA2__GPIO3_IO24		0x31e
++			MX93_PAD_SD3_DATA3__GPIO3_IO25		0x31e
++		>;
++	};
+ };
+ 
+ &lpi2c1 {
+@@ -544,7 +605,7 @@ &usbotg2 {
+ 	status = "okay";
+ };
+ 
+-&usdhc1 {
++&usdhc1 { /* eMMC */
+ 	pinctrl-names = "default", "state_100mhz", "state_200mhz";
+ 	pinctrl-0 = <&pinctrl_usdhc1>;
+ 	pinctrl-1 = <&pinctrl_usdhc1_100mhz>;
+@@ -554,7 +615,7 @@ &usdhc1 {
+ 	status = "okay";
+ };
+ 
+-&usdhc2 {
++&usdhc2 { /* SD-Card / SDIO A */
+ 	pinctrl-names = "default", "state_100mhz", "state_200mhz", "sleep";
+ 	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_gpio>;
+ 	pinctrl-1 = <&pinctrl_usdhc2_100mhz>, <&pinctrl_usdhc2_gpio>;
+@@ -568,3 +629,18 @@ &usdhc2 {
+ 	no-sdio;
+ 	no-mmc;
+ };
++
++&usdhc3 { /* SDIO B */
++	pinctrl-names = "default", "state_100mhz", "state_200mhz", "sleep";
++	pinctrl-0 = <&pinctrl_usdhc3>;
++	pinctrl-1 = <&pinctrl_usdhc3_100mhz>;
++	pinctrl-2 = <&pinctrl_usdhc3_200mhz>;
++	pinctrl-3 = <&pinctrl_usdhc3_sleep>;
++	mmc-pwrseq = <&usdhc3_pwrseq>;
++	vmmc-supply = <&reg_usdhc3_vmmc>;
++	bus-width = <4>;
++	pm-ignore-notify;
++	keep-power-in-suspend;
++	non-removable;
++	status = "okay";
++};
+\ No newline at end of file
+-- 
+2.30.2
+

--- a/recipes-kernel/linux/linux-fslc-imx_6.6.bbappend
+++ b/recipes-kernel/linux/linux-fslc-imx_6.6.bbappend
@@ -27,4 +27,5 @@ SRC_URI += " \
     file://0023-arm64-boot-dts-iesy-add-support-for-audio-input-and-.patch \
     file://0024-arm64-dts-iesy-add-csi-nodes.patch \
     file://0025-arm64-dts-iesy-add-support-for-dsi-functionality.patch \
+    file://0026-arm64-dts-iesy-add-support-for-sdio-b.patch \
 "


### PR DESCRIPTION
add nodes for usdhc3 and add nxp9098-sdio driver to .conf file