### PR TITLE
AM62XX EVA MI: add support for DFU, fix rootfs device

### DIFF
--- a/recipes-bsp/u-boot/u-boot-ti-staging/0003-board-ti-am62x-set-rootfs-device-from-boot-device.patch
+++ b/recipes-bsp/u-boot/u-boot-ti-staging/0003-board-ti-am62x-set-rootfs-device-from-boot-device.patch
@@ -40,7 +40,7 @@ index 9146361b3aa..9e5585a7596 100644
 +		break;
 +	}
 +
-+	env_set("root", "/dev/mmcblk${mmcdev}p2");
++	env_set("rootfs", "/dev/mmcblk${mmcdev}p2");
 +
  	return 0;
  }

--- a/recipes-bsp/u-boot/u-boot-ti-staging/0004-board-ti-am62x-set-rootfs-and-bootpart-depending-on-.patch
+++ b/recipes-bsp/u-boot/u-boot-ti-staging/0004-board-ti-am62x-set-rootfs-and-bootpart-depending-on-.patch
@@ -1,0 +1,50 @@
+From 4489a3c2816687483117bf7a3db92ce1037e81cf Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Tue, 15 Oct 2024 17:48:59 +0200
+Subject: [PATCH 4/7] board: ti: am62x: set rootfs and bootpart depending on
+ boot device
+
+Signed-off-by: Dominik Poggel <pog@iesy.com>
+---
+ board/ti/am62x/evm.c | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/board/ti/am62x/evm.c b/board/ti/am62x/evm.c
+index 555b24f524f..9770baad5e0 100644
+--- a/board/ti/am62x/evm.c
++++ b/board/ti/am62x/evm.c
+@@ -408,22 +408,24 @@ int board_late_init(void)
+ 
+ 	switch (bootmode) {
+ 	case BOOT_DEVICE_EMMC:
+-		// env_set("mmc_boot_dev", "emmc");
+ 		env_set_ulong("mmcdev", 0);
++		env_set("bootpart", "0:2");
++		env_set("rootfs", "/dev/mmcblk0p2");
+ 		break;
+ 	case BOOT_DEVICE_MMC:
+ 		if ((bootmode_cfg & MAIN_DEVSTAT_PRIMARY_MMC_PORT_MASK) >>
+-				MAIN_DEVSTAT_PRIMARY_MMC_PORT_SHIFT)
+-			// env_set("mmc_boot_dev", "sd");
++				MAIN_DEVSTAT_PRIMARY_MMC_PORT_SHIFT) {
+ 			env_set_ulong("mmcdev", 1);
+-		else
+-			// env_set("mmc_boot_dev", "emmc");
++			env_set("bootpart", "1:2");
++			env_set("rootfs", "/dev/mmcblk1p2");
++		} else {
+ 			env_set_ulong("mmcdev", 0);
++			env_set("bootpart", "0:2");
++			env_set("rootfs", "/dev/mmcblk0p2");
++		}
+ 		break;
+ 	}
+ 
+-	env_set("rootfs", "/dev/mmcblk${mmcdev}p2");
+-
+ 	return 0;
+ }
+ #endif
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/u-boot-ti-staging/0005-environment-ti-use-rootfs-var-for-root.patch
+++ b/recipes-bsp/u-boot/u-boot-ti-staging/0005-environment-ti-use-rootfs-var-for-root.patch
@@ -1,0 +1,26 @@
+From 907086f0ca1d2b03cd1f5435279d2b029605304b Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Tue, 15 Oct 2024 17:49:35 +0200
+Subject: [PATCH 5/7] environment: ti: use rootfs var for root
+
+Signed-off-by: Dominik Poggel <pog@iesy.com>
+---
+ include/environment/ti/mmc.env | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/environment/ti/mmc.env b/include/environment/ti/mmc.env
+index 1e62bf85daf..0868278c4ec 100644
+--- a/include/environment/ti/mmc.env
++++ b/include/environment/ti/mmc.env
+@@ -3,7 +3,7 @@ mmcrootfstype=ext4 rootwait
+ finduuid=part uuid ${boot} ${bootpart} uuid
+ args_mmc=run finduuid;setenv bootargs console=${console}
+ 	${optargs}
+-	root=PARTUUID=${uuid} rw
++	root=${rootfs}
+ 	rootfstype=${mmcrootfstype}
+ loadbootscript=load mmc ${mmcdev} ${loadaddr} boot.scr
+ bootscript=echo Running bootscript from mmc${mmcdev} ...;
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/u-boot-ti-staging/0006-environment-ti-update-dfu-for-fs-on-emmc-and-raw-ima.patch
+++ b/recipes-bsp/u-boot/u-boot-ti-staging/0006-environment-ti-update-dfu-for-fs-on-emmc-and-raw-ima.patch
@@ -1,0 +1,42 @@
+From e3c5577caba902fd3150b96997198c97da677032 Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Tue, 15 Oct 2024 17:50:11 +0200
+Subject: [PATCH 6/7] environment: ti: update dfu for fs on emmc and raw image
+
+Signed-off-by: Dominik Poggel <pog@iesy.com>
+---
+ include/environment/ti/k3_dfu.env | 18 +++++++++++-------
+ 1 file changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/include/environment/ti/k3_dfu.env b/include/environment/ti/k3_dfu.env
+index 3f5739dadfd..bd142602bc0 100644
+--- a/include/environment/ti/k3_dfu.env
++++ b/include/environment/ti/k3_dfu.env
+@@ -8,13 +8,17 @@ dfu_alt_info_mmc=
+ 	sysfw.itb fat 1 1
+ 
+ dfu_alt_info_emmc=
+-	rawemmc raw 0 0x800000 mmcpart 1;
+-	rootfs part 0 1;
+-	tiboot3.bin.raw raw 0x0 0x400 mmcpart 1;
+-	tispl.bin.raw raw 0x400 0x1000 mmcpart 1;
+-	u-boot.img.raw raw 0x1400 0x2000 mmcpart 1;
+-	u-env.raw raw 0x3400 0x100 mmcpart 1;
+-	sysfw.itb.raw raw 0x3600 0x800 mmcpart 1
++	rawemmc raw 0 0x800000;
++	boot part 0 1;
++	rootfs part 0 2;
++	tiboot3.bin fat 0 1;
++	tispl.bin fat 0 1;
++	u-boot.img fat 0 1;
++	uEnv.txt fat 0 1;
++	sysfw.itb fat 0 1
++
++dfu_alt_info_raw=
++	rawemmc raw 0 0x800000
+ 
+ dfu_alt_info_ospi=
+ 	tiboot3.bin raw 0x0 0x080000;
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
@@ -4,6 +4,9 @@ SRC_URI += " \
     file://0001-arm-dts-add-ddr-timing.patch \
     file://0002-board-ti-am62x-use-iesy-device-tree.patch \
     file://0003-board-ti-am62x-set-rootfs-device-from-boot-device.patch \
+    file://0004-board-ti-am62x-set-rootfs-and-bootpart-depending-on-.patch \
+    file://0005-environment-ti-use-rootfs-var-for-root.patch \
+    file://0006-environment-ti-update-dfu-for-fs-on-emmc-and-raw-ima.patch \
 "
 
 # file://0001-arm-dts-add-support-for-iesy-am62xx-eva-mi.patch


### PR DESCRIPTION
- add dfu_alt_info for flashing emmc
- fix rootfs env for both boot devices