### PR TITLE
i.MX8MM EVA MI: enable USB A roleswitch, fix USB B hotplug

### DIFF
--- a/recipes-kernel/linux/linux-fslc-imx/0032-arm64-dts-iesy-add-usb-role-switch-to-usbotg1-fix-us.patch
+++ b/recipes-kernel/linux/linux-fslc-imx/0032-arm64-dts-iesy-add-usb-role-switch-to-usbotg1-fix-us.patch
@@ -1,0 +1,184 @@
+From 22520c4070c2136ccbb08942f7a6439ae0e38770 Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Thu, 31 Oct 2024 15:34:07 +0100
+Subject: [PATCH 32/32] arm64: dts: iesy: add usb role switch to usbotg1, fix
+ usbotg2
+
+switch VBUS dependent on ID pin for usbotg1, fix hotplug on usbotg2
+
+Signed-off-by: Dominik Poggel <pog@iesy.com>
+---
+ .../boot/dts/iesy/iesy-imx8mm-eva-mi-v1.dts   | 36 +++++++++++++
+ .../boot/dts/iesy/iesy-imx8mm-osm-sf.dtsi     | 53 +++++--------------
+ 2 files changed, 50 insertions(+), 39 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/iesy/iesy-imx8mm-eva-mi-v1.dts b/arch/arm64/boot/dts/iesy/iesy-imx8mm-eva-mi-v1.dts
+index 5c5d71af225b..614100e3989b 100644
+--- a/arch/arm64/boot/dts/iesy/iesy-imx8mm-eva-mi-v1.dts
++++ b/arch/arm64/boot/dts/iesy/iesy-imx8mm-eva-mi-v1.dts
+@@ -22,6 +22,28 @@ cam24m: cam24m {
+ 		clock-output-names = "cam24m";
+ 	};
+ 
++	connector {
++		compatible = "gpio-usb-b-connector", "usb-b-connector";
++		type = "micro";
++		label = "USB_A";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_usb1_connector>;
++		id-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@0 {
++				reg = <0>;
++
++				usb_dr_connector: endpoint {
++					remote-endpoint = <&usb1_drd_sw>;
++				};
++			};
++		};
++	};
++
+ 	leds {
+ 		compatible = "gpio-leds";
+ 		pinctrl-names = "default";
+@@ -180,6 +202,14 @@ &pcie0 {
+ 	status = "okay";
+ };
+ 
++&usbotg1 {
++	port {
++		usb1_drd_sw: endpoint {
++			remote-endpoint = <&usb_dr_connector>;
++		};
++	};
++};
++
+ &usdhc1 {
+ 	bus-width = <4>;
+ 	status = "okay";
+@@ -404,6 +434,12 @@ MX8MM_IOMUXC_SAI5_RXD1_SAI5_TX_SYNC		0x100
+ 			MX8MM_IOMUXC_SAI2_MCLK_SAI5_MCLK		0x100
+ 		>;
+ 	};
++
++	pinctrl_usb1_connector: usb1connectorgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO10_GPIO1_IO10		0x1c0
++		>;
++	};
+ };
+ 
+ &lcdif {
+diff --git a/arch/arm64/boot/dts/iesy/iesy-imx8mm-osm-sf.dtsi b/arch/arm64/boot/dts/iesy/iesy-imx8mm-osm-sf.dtsi
+index 5ad7b4f8cb8a..20051732b48e 100644
+--- a/arch/arm64/boot/dts/iesy/iesy-imx8mm-osm-sf.dtsi
++++ b/arch/arm64/boot/dts/iesy/iesy-imx8mm-osm-sf.dtsi
+@@ -49,16 +49,6 @@ reg_usdhc2_vmmc: regulator-usdhc2 {
+ 		enable-active-high;
+ 	};
+ 
+-	reg_usb_a_vbus: regulator@1 {
+-		compatible = "regulator-fixed";
+-		regulator-name = "USB_A_VBUS";
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-		gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+-		off-on-delay = <20000>;
+-		enable-active-high;
+-    };
+-
+ 	reg_usb_b_vbus: regulator@2 {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "USB_B_VBUS";
+@@ -67,6 +57,8 @@ reg_usb_b_vbus: regulator@2 {
+ 		gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+ 		off-on-delay = <20000>;
+ 		enable-active-high;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_usb2_reg>;
+     };
+ };
+ 
+@@ -141,12 +133,11 @@ &uart4 { /* UART A */
+ };
+ 
+ &usbotg1 {
+-	vbus-supply = <&reg_usb_a_vbus>;
+ 	over-current-active-low;
+ 	dr_mode = "otg";
+-	pinctrl-names = "idle", "active";
+-	pinctrl-0 = <&pinctrl_usb1_idle>;
+-	pinctrl-1 = <&pinctrl_usb1_active>;
++	power-active-high;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_usb1>;
+ 	status = "okay";
+ };
+ 
+@@ -154,16 +145,11 @@ &usbotg2 {
+ 	vbus-supply = <&reg_usb_b_vbus>;
+ 	over-current-active-low;
+ 	dr_mode = "host";
+-	pinctrl-names = "idle", "active";
+-	pinctrl-0 = <&pinctrl_usb2_idle>;
+-	pinctrl-1 = <&pinctrl_usb2_active>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_usb2>;
+ 	status = "okay";
+ };
+ 
+-&usbphynop1 {
+-	vcc-supply = <&reg_usb_a_vbus>;
+-};
+-
+ &usbphynop2 {
+ 	vcc-supply = <&reg_usb_b_vbus>;
+ };
+@@ -461,33 +447,22 @@ MX8MM_IOMUXC_ECSPI2_SS0_UART4_DCE_RTS_B		0x140
+ 		>;
+ 	};
+ 
+-    pinctrl_usb1_idle: usb1idl {
++	pinctrl_usb1: usb1grp {
+ 		fsl,pins = <
+-			MX8MM_IOMUXC_GPIO1_IO10_USB1_OTG_ID 0x140
+-			MX8MM_IOMUXC_GPIO1_IO12_GPIO1_IO12	0x0
+-			MX8MM_IOMUXC_GPIO1_IO13_GPIO1_IO13	0x140
++			MX8MM_IOMUXC_GPIO1_IO12_USB1_OTG_PWR	0x84
++			MX8MM_IOMUXC_GPIO1_IO13_USB1_OTG_OC		0x84
+ 		>;
+ 	};
+ 
+-	pinctrl_usb1_active: usb1act {
++	pinctrl_usb2: usb2grp {
+ 		fsl,pins = <
+-			MX8MM_IOMUXC_GPIO1_IO10_USB1_OTG_ID 0x140
+-			MX8MM_IOMUXC_GPIO1_IO12_GPIO1_IO12	0x0		/* PWR_EN */
+-			MX8MM_IOMUXC_GPIO1_IO13_USB1_OTG_OC	0x140
+-		>;
+-	};
+-
+-	pinctrl_usb2_idle: usb2idl {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_GPIO1_IO15_GPIO1_IO15	0x140
+-			MX8MM_IOMUXC_GPIO1_IO14_GPIO1_IO14	0x0
++			MX8MM_IOMUXC_GPIO1_IO15_USB2_OTG_OC	0x140
+ 		>;
+ 	};
+ 
+-	pinctrl_usb2_active: usb2act {
++	pinctrl_usb2_reg: usb2reggrp {
+ 		fsl,pins = <
+-			MX8MM_IOMUXC_GPIO1_IO15_USB2_OTG_OC	0x140
+-			MX8MM_IOMUXC_GPIO1_IO14_GPIO1_IO14	0x0		/* PWR_EN */
++			MX8MM_IOMUXC_GPIO1_IO14_GPIO1_IO14	0x140
+ 		>;
+ 	};
+ 
+-- 
+2.30.2
+

--- a/recipes-kernel/linux/linux-fslc-imx_6.6.bbappend
+++ b/recipes-kernel/linux/linux-fslc-imx_6.6.bbappend
@@ -33,4 +33,5 @@ SRC_URI += " \
     file://0029-arm64-dts-iesy-add-imx219-camera-sensor.patch \
     file://0030-arm64-dts-iesy-remove-unused-nodes-from-i.MX93-eval-.patch \
     file://0031-arm64-dts-iesy-fix-audio.patch \
+    file://0032-arm64-dts-iesy-add-usb-role-switch-to-usbotg1-fix-us.patch \
 "


### PR DESCRIPTION
add USB connector to usbotg1, switch pinctrl for usbotg2 from "active" & "idle" to "default", enables/fixes hotplug detection