### PR TITLE
i.MX93 EVA MI: change used weston to nxp weston

### DIFF
--- a/conf/machine/iesy-imx93-eva-mi.conf
+++ b/conf/machine/iesy-imx93-eva-mi.conf
@@ -17,8 +17,6 @@ BBMASK += " \
 	.*linux-ti.*.bbappend \
 	.*u-boot-ti.*.bbappend \
 	"
-# should be removed once the cause for why the nxp weston versions do not work is found out
-BBMASK += "meta-freescale/recipes-graphics/wayland/weston_.*\.imx\.bb"
 
 MACHINE_FEATURES:append = " nxp9098-sdio"
 

--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,0 +1,7 @@
+do_install:append:iesy-imx93-eva-mi() {
+    sed -i '/^\[core\]/a\backend=drm-backend.so' ${D}${sysconfdir}/xdg/weston/weston.ini
+
+    install -d ${D}${sysconfdir}/udev/rules.d
+    echo 'SUBSYSTEM=="dma_heap", KERNEL=="linux,cma*", GROUP="video", MODE="0660"' >> ${D}${sysconfdir}/udev/rules.d/99-weston-rule.rules
+    echo 'KERNEL=="pxp_device", GROUP="video", MODE="0660"' >> ${D}${sysconfdir}/udev/rules.d/99-weston-rule.rules
+}


### PR DESCRIPTION
Change used Weston to the NXP-specific Weston, which utilizes 2D hardware acceleration. Also, update the backend used by Weston to drm-backend and add udev rules so that the dma_heap and pxp_device can be read and written by the video group.