### PR TITLE
update patches to u-boot-imx-2024.04

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx/0002-arch-arm-Add-support-for-iesy-imx93-eva-mi.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0002-arch-arm-Add-support-for-iesy-imx93-eva-mi.patch
@@ -1,6 +1,6 @@
-From f1a62df56a4a337cfaaeaf7ba16c8e4333ca73b4 Mon Sep 17 00:00:00 2001
+From 236df71db454556da1f213c74933bb81fdf92dcf Mon Sep 17 00:00:00 2001
 From: Dominik Poggel <pog@iesy.com>
-Date: Fri, 9 Aug 2024 14:53:05 +0200
+Date: Thu, 19 Dec 2024 16:26:50 +0100
 Subject: [PATCH 2/2] arch: arm: Add support for iesy-imx93-eva-mi
 
 Signed-off-by: Dominik Poggel <pog@iesy.com>
@@ -13,11 +13,11 @@ Signed-off-by: Dominik Poggel <pog@iesy.com>
  board/iesy/iesy_imx93_eva_mi/MAINTAINERS      |    7 +
  board/iesy/iesy_imx93_eva_mi/Makefile         |   12 +
  .../iesy_imx93_eva_mi/iesy_imx93_eva_mi.c     |  405 +++++
- board/iesy/iesy_imx93_eva_mi/lpddr4_timing.c  | 1545 +++++++++++++++++
+ board/iesy/iesy_imx93_eva_mi/lpddr4_timing.c  | 1544 +++++++++++++++++
  board/iesy/iesy_imx93_eva_mi/spl.c            |  188 ++
  configs/iesy_imx93_eva_mi_defconfig           |  190 ++
  include/configs/iesy_imx93_eva_mi.h           |  187 ++
- 12 files changed, 3414 insertions(+)
+ 12 files changed, 3413 insertions(+)
  create mode 100644 arch/arm/dts/iesy-imx93-eva-mi-u-boot.dtsi
  create mode 100644 arch/arm/dts/iesy-imx93-eva-mi.dts
  create mode 100644 board/iesy/iesy_imx93_eva_mi/Kconfig
@@ -30,17 +30,17 @@ Signed-off-by: Dominik Poggel <pog@iesy.com>
  create mode 100644 include/configs/iesy_imx93_eva_mi.h
 
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index 8aab6abdbc2..4cec7310e9b 100644
+index bfca4182ad9..3374da85dc4 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -1086,6 +1086,7 @@ dtb-$(CONFIG_ARCH_IMX8M) += \
+@@ -1185,6 +1185,7 @@ dtb-$(CONFIG_ARCH_IMX8M) += \
  	imx8mq-librem5-r4.dtb
  
  dtb-$(CONFIG_ARCH_IMX9) += \
 +	iesy-imx93-eva-mi.dtb \
+ 	imx95-15x15-evk.dtb \
  	imx95-19x19-evk.dtb \
- 	imx95-19x19-titan.dtb \
- 	imx93-11x11-evk.dtb \
+ 	imx95-19x19-verdin.dtb \
 diff --git a/arch/arm/dts/iesy-imx93-eva-mi-u-boot.dtsi b/arch/arm/dts/iesy-imx93-eva-mi-u-boot.dtsi
 new file mode 100644
 index 00000000000..d85e6d69b41
@@ -914,10 +914,10 @@ index 00000000000..fb1b32c474a
 +	status = "okay";
 +};
 diff --git a/arch/arm/mach-imx/imx9/Kconfig b/arch/arm/mach-imx/imx9/Kconfig
-index 2e306fa5add..b6bc14caa2a 100644
+index 1f78b1b6a31..bf331a0721d 100644
 --- a/arch/arm/mach-imx/imx9/Kconfig
 +++ b/arch/arm/mach-imx/imx9/Kconfig
-@@ -56,6 +56,12 @@ config TARGET_IMX95_19X19_EVK
+@@ -72,6 +72,12 @@ config TARGET_IMX95_19X19_EVK
  	bool "imx95_19x19_evk"
  	select IMX95
  
@@ -927,15 +927,15 @@ index 2e306fa5add..b6bc14caa2a 100644
 +	select IMX93
 +	select IMX9_LPDDR4X
 +
- config TARGET_TITAN_IMX95_19X19
- 	bool "imx95_titan_evk"
+ config TARGET_VERDIN_IMX95_19X19
+ 	bool "imx95_verdin_evk"
  	select IMX95
-@@ -65,6 +71,7 @@ endchoice
- source "board/freescale/imx93_evk/Kconfig"
+@@ -89,6 +95,7 @@ source "board/phytec/phycore_imx93/Kconfig"
+ source "board/variscite/imx93_var_som/Kconfig"
  source "board/freescale/imx93_qsb/Kconfig"
  source "board/freescale/imx95_evk/Kconfig"
 +source "board/iesy/iesy_imx93_eva_mi/Kconfig"
- source "board/toradex/titan-imx95/Kconfig"
+ source "board/toradex/verdin-imx95/Kconfig"
  
  endif
 diff --git a/board/iesy/iesy_imx93_eva_mi/Kconfig b/board/iesy/iesy_imx93_eva_mi/Kconfig
@@ -1400,10 +1400,10 @@ index 00000000000..2a448c5e194
 +}
 diff --git a/board/iesy/iesy_imx93_eva_mi/lpddr4_timing.c b/board/iesy/iesy_imx93_eva_mi/lpddr4_timing.c
 new file mode 100644
-index 00000000000..0de03497368
+index 00000000000..b24728712f0
 --- /dev/null
 +++ b/board/iesy/iesy_imx93_eva_mi/lpddr4_timing.c
-@@ -0,0 +1,1545 @@
+@@ -0,0 +1,1544 @@
 +/*
 + * Copyright 2024 NXP
 + *
@@ -2948,7 +2948,6 @@ index 00000000000..0de03497368
 +    .fsp_cfg = ddr_dram_fsp_cfg,
 +    .fsp_cfg_num = ARRAY_SIZE(ddr_dram_fsp_cfg),
 +};
-+
 diff --git a/board/iesy/iesy_imx93_eva_mi/spl.c b/board/iesy/iesy_imx93_eva_mi/spl.c
 new file mode 100644
 index 00000000000..368a9b3ba63

--- a/recipes-bsp/u-boot/u-boot-imx/0007-board-iesy-iesy_imx8mm_eva_mi-add-missing-include.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0007-board-iesy-iesy_imx8mm_eva_mi-add-missing-include.patch
@@ -1,0 +1,24 @@
+From 152ee21c00d6b2431202c38a68c5db3e00cb09fa Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Tue, 7 Jan 2025 09:48:34 +0100
+Subject: [PATCH 7/8] board: iesy: iesy_imx8mm_eva_mi: add missing include
+
+---
+ board/iesy/iesy_imx8mm_eva_mi/spl.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/board/iesy/iesy_imx8mm_eva_mi/spl.c b/board/iesy/iesy_imx8mm_eva_mi/spl.c
+index 6380b34bd29..269c2da0f2c 100644
+--- a/board/iesy/iesy_imx8mm_eva_mi/spl.c
++++ b/board/iesy/iesy_imx8mm_eva_mi/spl.c
+@@ -19,6 +19,7 @@
+ #include <asm/arch/sys_proto.h>
+ #include <asm/mach-imx/boot_mode.h>
+ #include <asm/arch/ddr.h>
++#include <asm/sections.h>
+ 
+ #include <power/pmic.h>
+ #ifdef CONFIG_POWER_PCA9450
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/u-boot-imx/0008-configs-iesy_imx8mm_eva_mi_v1_defconfig-disable-EFI-.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0008-configs-iesy_imx8mm_eva_mi_v1_defconfig-disable-EFI-.patch
@@ -1,0 +1,25 @@
+From 9b7a5f38ee461df115966ec9c566466663fba522 Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Tue, 7 Jan 2025 10:08:32 +0100
+Subject: [PATCH 8/8] configs: iesy_imx8mm_eva_mi_v1_defconfig: disable EFI
+ capsule auth
+
+---
+ configs/iesy_imx8mm_eva_mi_v1_defconfig | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/configs/iesy_imx8mm_eva_mi_v1_defconfig b/configs/iesy_imx8mm_eva_mi_v1_defconfig
+index fa10552a24e..3433323a282 100644
+--- a/configs/iesy_imx8mm_eva_mi_v1_defconfig
++++ b/configs/iesy_imx8mm_eva_mi_v1_defconfig
+@@ -218,7 +218,6 @@ CONFIG_SPL_RSA=y
+ CONFIG_SHA384=y
+ CONFIG_EFI_VAR_BUF_SIZE=139264
+ CONFIG_EFI_IGNORE_OSINDICATIONS=y
+-CONFIG_EFI_CAPSULE_AUTHENTICATE=y
+ CONFIG_OPTEE=y
+ CONFIG_CMD_OPTEE_RPMB=y
+ CONFIG_EFI_MM_COMM_TEE=y
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/u-boot-imx/0009-board-iesy_imx93_eva_mi-add-missing-include-fix-RNG-.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0009-board-iesy_imx93_eva_mi-add-missing-include-fix-RNG-.patch
@@ -1,0 +1,35 @@
+From e41fee69720de4e45eacca915373eebdffaaa0a6 Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Fri, 10 Jan 2025 10:05:47 +0100
+Subject: [PATCH 09/11] board: iesy_imx93_eva_mi: add missing include, fix RNG
+ call
+
+change from ahab (advanced high assurance boot) to ele (edgelock enclave)
+---
+ board/iesy/iesy_imx93_eva_mi/spl.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/board/iesy/iesy_imx93_eva_mi/spl.c b/board/iesy/iesy_imx93_eva_mi/spl.c
+index 368a9b3ba63..d75868b8742 100644
+--- a/board/iesy/iesy_imx93_eva_mi/spl.c
++++ b/board/iesy/iesy_imx93_eva_mi/spl.c
+@@ -29,6 +29,7 @@
+ #include <asm/arch/clock.h>
+ #include <asm/arch/ccm_regs.h>
+ #include <asm/arch/ddr.h>
++#include <asm/sections.h>
+ #include <power/pmic.h>
+ #include <power/pca9450.h>
+ #include <power/pf0900.h>
+@@ -60,7 +61,7 @@ void spl_board_init(void)
+ 
+ 	puts("Normal Boot\n");
+ 
+-	ret = ahab_start_rng();
++	ret = ele_start_rng();
+ 	if (ret)
+ 		printf("Fail to start RNG: %d\n", ret);
+ }
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/u-boot-imx/0010-configs-iesy_imx93-disable-EFI-capsule-auth-enable-C.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0010-configs-iesy_imx93-disable-EFI-capsule-auth-enable-C.patch
@@ -1,0 +1,39 @@
+From ba05d545494c2fe7795532c17d4cb66bf6e37b78 Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Fri, 10 Jan 2025 10:06:45 +0100
+Subject: [PATCH 10/11] configs: iesy_imx93: disable EFI capsule auth,  enable
+ CPU,add container
+
+---
+ configs/iesy_imx93_eva_mi_defconfig | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/configs/iesy_imx93_eva_mi_defconfig b/configs/iesy_imx93_eva_mi_defconfig
+index 73c19b451c4..05ffc544a66 100644
+--- a/configs/iesy_imx93_eva_mi_defconfig
++++ b/configs/iesy_imx93_eva_mi_defconfig
+@@ -20,6 +20,7 @@ CONFIG_SPL=y
+ CONFIG_CMD_DEKBLOB=y
+ CONFIG_SPL_IMX_ROMAPI_LOADADDR=0x88000000
+ CONFIG_SPL_LOAD_IMX_CONTAINER=y
++CONFIG_IMX_CONTAINER_CFG="arch/arm/mach-imx/imx9/container.cfg"
+ CONFIG_SYS_LOAD_ADDR=0x80400000
+ CONFIG_SYS_MEMTEST_START=0x80000000
+ CONFIG_SYS_MEMTEST_END=0x90000000
+@@ -92,6 +93,8 @@ CONFIG_SPL_DM=y
+ CONFIG_SYSCON=y
+ CONFIG_SPL_CLK_IMX93=y
+ CONFIG_CLK_IMX93=y
++CONFIG_CPU=y
++CONFIG_CPU_IMX=y
+ CONFIG_DFU_MMC=y
+ CONFIG_DFU_RAM=y
+ CONFIG_USB_FUNCTION_FASTBOOT=y
+@@ -187,4 +190,3 @@ CONFIG_EFI_RUNTIME_UPDATE_CAPSULE=y
+ CONFIG_EFI_CAPSULE_ON_DISK=y
+ CONFIG_EFI_IGNORE_OSINDICATIONS=y
+ CONFIG_EFI_CAPSULE_FIRMWARE_RAW=y
+-CONFIG_EFI_CAPSULE_AUTHENTICATE=y
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/u-boot-imx/0011-arm-dts-remove-type-c-nodes.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0011-arm-dts-remove-type-c-nodes.patch
@@ -1,0 +1,122 @@
+From 7aade014c208429347893962a74efe7929f5db11 Mon Sep 17 00:00:00 2001
+From: Dominik Poggel <pog@iesy.com>
+Date: Fri, 10 Jan 2025 10:07:37 +0100
+Subject: [PATCH 11/11] arm: dts: remove type c nodes
+
+nodes caused build errors, are not present on eval kit, artefacts from nxp eval kit
+---
+ arch/arm/dts/iesy-imx93-eva-mi-u-boot.dtsi |  2 -
+ arch/arm/dts/iesy-imx93-eva-mi.dts         | 66 ----------------------
+ 2 files changed, 68 deletions(-)
+
+diff --git a/arch/arm/dts/iesy-imx93-eva-mi-u-boot.dtsi b/arch/arm/dts/iesy-imx93-eva-mi-u-boot.dtsi
+index 3256a77cbd9..cafd5936bf1 100644
+--- a/arch/arm/dts/iesy-imx93-eva-mi-u-boot.dtsi
++++ b/arch/arm/dts/iesy-imx93-eva-mi-u-boot.dtsi
+@@ -159,12 +159,10 @@
+ 
+ &usbotg1 {
+ 	status = "okay";
+-	extcon = <&ptn5110>;
+ };
+ 
+ &usbotg2 {
+ 	status = "okay";
+-	extcon = <&ptn5110_2>;
+ };
+ 
+ &s4muap {
+diff --git a/arch/arm/dts/iesy-imx93-eva-mi.dts b/arch/arm/dts/iesy-imx93-eva-mi.dts
+index ab1e869a510..f85fcaa295c 100644
+--- a/arch/arm/dts/iesy-imx93-eva-mi.dts
++++ b/arch/arm/dts/iesy-imx93-eva-mi.dts
+@@ -316,60 +316,6 @@ dsi_host: dsi-host {
+ 		interrupts = <1 IRQ_TYPE_LEVEL_LOW>;
+ 		status = "okay";
+ 	};
+-
+-	ptn5110: tcpc@50 {
+-		compatible = "nxp,ptn5110";
+-		reg = <0x50>;
+-		interrupt-parent = <&pcal6524>;
+-		interrupts = <1 IRQ_TYPE_EDGE_FALLING>;
+-		status = "okay";
+-
+-		port {
+-			typec1_dr_sw: endpoint {
+-				remote-endpoint = <&usb1_drd_sw>;
+-			};
+-		};
+-
+-		typec1_con: connector {
+-			compatible = "usb-c-connector";
+-			label = "USB-C";
+-			power-role = "dual";
+-			data-role = "dual";
+-			try-power-role = "sink";
+-			source-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
+-			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
+-				     PDO_VAR(5000, 20000, 3000)>;
+-			op-sink-microwatt = <15000000>;
+-			self-powered;
+-		};
+-	};
+-
+-	ptn5110_2: tcpc@51 {
+-		compatible = "nxp,ptn5110";
+-		reg = <0x51>;
+-		interrupt-parent = <&pcal6524>;
+-		interrupts = <9 IRQ_TYPE_EDGE_FALLING>;
+-		status = "okay";
+-
+-		port {
+-			typec2_dr_sw: endpoint {
+-				remote-endpoint = <&usb2_drd_sw>;
+-			};
+-		};
+-
+-		typec2_con: connector {
+-			compatible = "usb-c-connector";
+-			label = "USB-C";
+-			power-role = "dual";
+-			data-role = "dual";
+-			try-power-role = "sink";
+-			source-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
+-			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
+-				     PDO_VAR(5000, 20000, 3000)>;
+-			op-sink-microwatt = <15000000>;
+-			self-powered;
+-		};
+-	};
+ };
+ 
+ &lpuart1 { /* console */
+@@ -388,12 +334,6 @@ dsi_host: dsi-host {
+ 	samsung,picophy-pre-emp-curr-control = <3>;
+ 	samsung,picophy-dc-vol-level-adjust = <7>;
+ 	status = "okay";
+-
+-	port {
+-		usb1_drd_sw: endpoint {
+-			remote-endpoint = <&typec1_dr_sw>;
+-		};
+-	};
+ };
+ 
+ &usbotg2 {
+@@ -406,12 +346,6 @@ dsi_host: dsi-host {
+ 	samsung,picophy-pre-emp-curr-control = <3>;
+ 	samsung,picophy-dc-vol-level-adjust = <7>;
+ 	status = "okay";
+-
+-	port {
+-		usb2_drd_sw: endpoint {
+-			remote-endpoint = <&typec2_dr_sw>;
+-		};
+-	};
+ };
+ 
+ &usdhc1 {
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -7,6 +7,11 @@ SRC_URI += " \
     file://0004-arch-arm-dts-moved-pmic-from-i2c2-to-i2c1-and-config.patch \
     file://0005-board-iesy-iesy_imx93_eva-adjust-lpddr4_timing.c.patch \
     file://0006-arm-dts-add-pullup-resistor-for-sd-card-writeprotect.patch \
+    file://0007-board-iesy-iesy_imx8mm_eva_mi-add-missing-include.patch \
+    file://0008-configs-iesy_imx8mm_eva_mi_v1_defconfig-disable-EFI-.patch \
+    file://0009-board-iesy_imx93_eva_mi-add-missing-include-fix-RNG-.patch \
+    file://0010-configs-iesy_imx93-disable-EFI-capsule-auth-enable-C.patch \
+    file://0011-arm-dts-remove-type-c-nodes.patch \
 "
 
 do_patch(){


### PR DESCRIPTION
i.mx8mm updated u-boot-imx to the 2024.04 version, update patch, disable EFI capsule auth, add missing include

i.mx893 add container config, remove unused nodes, fix RNG call